### PR TITLE
Fixes #11 Allow survey Id to be updated.

### DIFF
--- a/repositories/QuestionnaireRepository.js
+++ b/repositories/QuestionnaireRepository.js
@@ -29,10 +29,11 @@ module.exports.remove = function(id) {
     .then(head);
 };
 
-module.exports.update = function({ id, title, description, theme, legalBasis, navigation }) {
+module.exports.update = function({ id, title, description, theme, legalBasis, navigation, surveyId }) {
   return Questionnaire
     .update(id, {
       title,
+      surveyId,
       description,
       theme,
       legalBasis,

--- a/schema/mutations/updateQuestionnaire.js
+++ b/schema/mutations/updateQuestionnaire.js
@@ -27,6 +27,9 @@ module.exports = {
     },
     navigation : {
       type : GraphQLBoolean
+    },
+    surveyId : {
+        type: GraphQLString
     }
   },
 


### PR DESCRIPTION
## Description
This PR fixes #11 by re-introducing the `surveyId` argument in the UpdateQuestionnaire mutation.
There was a previous constraint on the API which prevented a survey Id from being updated.
This change removes that restriction.

## How to review
Run the mutation queries via the GraphiQL interfaces (using Docker).
Observe that the Update Questionnaire mutation allows surveyId to be passed in.
Observe that the survey Id is updated when mutation is executed.