### PR TITLE
Remove apt-get upgrade from Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM node:8
-RUN apt-get update -y && apt-get upgrade -y
 EXPOSE 4000
 WORKDIR /app
 ENTRYPOINT ["./scripts/run_app.sh"]


### PR DESCRIPTION
## Description
One of the issues highlighted by codacy automated code review tool was the use of `apt-get upgrade` in the Dockerfile.
I had a look through the [Docker documentation for apt-get](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#apt-get) and it seems they advise against performing an upgrade.

Also, a `apt-get update` is only useful if we plan on installing custom packages to the Docker image.
Since we're not doing that at the moment, we can remove this. This should significantly speed up the process of building our Docker images.

## How to review
`docker-compose build` should still work and able to run the API using Docker using `docker-compose up` as previous.