### PR TITLE
make backwards compatible

### DIFF
--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -1,3 +1,5 @@
+const { merge } = require("lodash");
+
 const Resolvers = {
   Query: {
     questionnaires: (_, args, ctx) => ctx.repositories.Questionnaire.findAll(),
@@ -39,8 +41,6 @@ const Resolvers = {
 
   Questionnaire: {
     sections: (questionnaire, args, ctx) =>
-      ctx.repositories.Section.findAll({ QuestionnaireId: questionnaire.id }),
-    groups: (questionnaire, args, ctx) =>
       ctx.repositories.Section.findAll({ QuestionnaireId: questionnaire.id })
   },
 
@@ -59,10 +59,18 @@ const Resolvers = {
   }
 };
 
-// BACKWARDS COMPATIBILITY FOR DEPRECATIONS
-Resolvers.Query.group = Resolvers.Query.section;
-Resolvers.Mutation.createGroup = Resolvers.Mutation.createSection;
-Resolvers.Mutation.updateGroup = Resolvers.Mutation.updateSection;
-Resolvers.Mutation.deleteGroup = Resolvers.Mutation.deleteSection;
+const Deprecations = {
+  Query: {
+    group: Resolvers.Query.section
+  },
+  Mutation: {
+    createGroup: Resolvers.Mutation.createSection,
+    updateGroup: Resolvers.Mutation.updateSection,
+    deleteGroup: Resolvers.Mutation.deleteSection
+  },
+  Questionnaire: {
+    groups: Resolvers.Questionnaire.sections
+  }
+};
 
-module.exports = Resolvers;
+module.exports = merge({}, Resolvers, Deprecations);

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -39,6 +39,8 @@ module.exports = {
 
   Questionnaire: {
     sections: (questionnaire, args, ctx) =>
+      ctx.repositories.Section.findAll({ QuestionnaireId: questionnaire.id }),
+    groups: (questionnaire, args, ctx) =>
       ctx.repositories.Section.findAll({ QuestionnaireId: questionnaire.id })
   },
 

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -1,4 +1,4 @@
-module.exports = {
+const Resolvers = {
   Query: {
     questionnaires: (_, args, ctx) => ctx.repositories.Questionnaire.findAll(),
     questionnaire: (root, { id }, ctx) =>
@@ -58,3 +58,11 @@ module.exports = {
       ctx.repositories.Answer.findAll({ QuestionPageId: id })
   }
 };
+
+// BACKWARDS COMPATIBILITY FOR DEPRECATIONS
+Resolvers.Query.group = Resolvers.Query.section;
+Resolvers.Mutation.createGroup = Resolvers.Mutation.createSection;
+Resolvers.Mutation.updateGroup = Resolvers.Mutation.updateSection;
+Resolvers.Mutation.deleteGroup = Resolvers.Mutation.deleteSection;
+
+module.exports = Resolvers;

--- a/schema/typeDefinitions.js
+++ b/schema/typeDefinitions.js
@@ -84,6 +84,7 @@ type Query {
     questionnaires: [Questionnaire]
     questionnaire(id: Int!): Questionnaire
     section(id: Int!): Section
+    group(id: Int!): Section @deprecated(reason: "use 'section' instead")
     page(id: Int!): Page
     questionPage(id: Int!): QuestionPage
     answer(id: Int!): Answer
@@ -97,6 +98,9 @@ type Mutation {
     createSection(title: String!, description: String, questionnaireId: Int!) : Section
     updateSection(id: Int!, title: String, description: String) : Section
     deleteSection(id: Int!) : Section
+    createGroup(title: String!, description: String, questionnaireId: Int!) : Section @deprecated(reason: "use 'createSection' instead")
+    updateGroup(id: Int!, title: String, description: String) : Section @deprecated(reason: "use 'updateSection' instead")
+    deleteGroup(id: Int!) : Section @deprecated(reason: "use 'deleteSection' instead")
 
     createPage(title: String!, description: String, sectionId: Int!) : Page
     updatePage(id: Int!, title: String!, description: String) : Page

--- a/schema/typeDefinitions.js
+++ b/schema/typeDefinitions.js
@@ -7,6 +7,7 @@ module.exports = `type Questionnaire {
     navigation: Boolean
     surveyId: String
     sections: [Section]
+    groups: [Section] @deprecated(reason: "use 'sections' instead")
 }
 
 type Section {


### PR DESCRIPTION
* adds `groups` back for backwards compatibility
* uses `@deprecated` directive to notify clients of deprecation (e.g. graphiql shows it is deprecated, and gives reason for deprecation)