### PR TITLE
Create initial section & page

### DIFF
--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -12,8 +12,25 @@ const Resolvers = {
   },
 
   Mutation: {
-    createQuestionnaire: (root, args, ctx) =>
-      ctx.repositories.Questionnaire.insert(args),
+    createQuestionnaire: async (root, args, ctx) => {
+      const questionnaire = await ctx.repositories.Questionnaire.insert(args);
+
+      const section = await ctx.repositories.Section.insert({
+        title: "",
+        description: "",
+        questionnaireId: questionnaire.id
+      });
+
+      await ctx.repositories.Page.insert({
+        pageType: "QuestionPage",
+        title: "",
+        description: "",
+        type: "General",
+        sectionId: section.id
+      });
+
+      return questionnaire;
+    },
     updateQuestionnaire: (_, args, ctx) =>
       ctx.repositories.Questionnaire.update(args),
     deleteQuestionnaire: (_, { id }, ctx) =>

--- a/schema/typeDefinitions.js
+++ b/schema/typeDefinitions.js
@@ -91,6 +91,7 @@ type Query {
 }
 
 type Mutation {
+    # creates a Questionnaire along with an initial Section and Page
     createQuestionnaire(title: String!, description: String, theme: String!, legalBasis: LegalBasis!, navigation: Boolean, surveyId: String!) : Questionnaire
     updateQuestionnaire(id: Int!, title: String, description: String, theme: String, legalBasis: LegalBasis, navigation: Boolean, surveyId: String) : Questionnaire
     deleteQuestionnaire(id: Int!) : Questionnaire

--- a/tests/schema/mutations/createAnswer.test.js
+++ b/tests/schema/mutations/createAnswer.test.js
@@ -1,8 +1,7 @@
 const executeQuery = require("../../utils/executeQuery");
 const mockRepository = require("../../utils/mockRepository");
 
-describe("createAnswer" , () => {
-
+describe("createAnswer", () => {
   const createAnswer = `
     mutation CreateAnswer(
       $description: String,
@@ -38,7 +37,7 @@ describe("createAnswer" , () => {
 
   beforeEach(() => {
     repositories = {
-      Answer : mockRepository("question")
+      Answer: mockRepository()
     };
   });
 

--- a/tests/schema/mutations/createQuestionnaire.test.js
+++ b/tests/schema/mutations/createQuestionnaire.test.js
@@ -1,8 +1,7 @@
 const executeQuery = require("../../utils/executeQuery");
 const mockRepository = require("../../utils/mockRepository");
 
-describe("createQuestionnaire" , () => {
-
+describe("createQuestionnaire", () => {
   const createQuestionnaire = `
     mutation CreateQuestionnaire(
       $title: String!,
@@ -32,25 +31,44 @@ describe("createQuestionnaire" , () => {
 
   let repositories;
 
+  const QUESTIONNAIRE_ID = 123;
+  const SECTION_ID = 456;
+
   beforeEach(() => {
     repositories = {
-      Questionnaire : mockRepository("question")
+      Questionnaire: mockRepository({
+        insert: { id: QUESTIONNAIRE_ID }
+      }),
+      Section: mockRepository({
+        insert: { id: SECTION_ID }
+      }),
+      Page: mockRepository()
     };
   });
 
   it("should allow creation of Questionnaire", async () => {
     const fixture = {
-      "title": "Test questionnaire",
-      "description": "This is a test questionnaire",
-      "theme": "test theme",
-      "legalBasis": "Voluntary",
-      "navigation": true,
-      "surveyId": "abc"
+      title: "Test questionnaire",
+      description: "This is a test questionnaire",
+      theme: "test theme",
+      legalBasis: "Voluntary",
+      navigation: true,
+      surveyId: "abc"
     };
 
-    const result = await executeQuery(createQuestionnaire, fixture, { repositories });
+    const result = await executeQuery(createQuestionnaire, fixture, {
+      repositories
+    });
 
     expect(result.errors).toBeUndefined();
+    expect(result.data.createQuestionnaire.id).toBe(QUESTIONNAIRE_ID);
+
     expect(repositories.Questionnaire.insert).toHaveBeenCalled();
+    expect(repositories.Section.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ questionnaireId: QUESTIONNAIRE_ID })
+    );
+    expect(repositories.Page.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ sectionId: SECTION_ID })
+    );
   });
 });

--- a/tests/utils/mockRepository.js
+++ b/tests/utils/mockRepository.js
@@ -1,9 +1,9 @@
-module.exports = function mockRepository() {
+module.exports = function mockRepository(returnValues = {}) {
   return {
-    get : jest.fn(),
-    findAll : jest.fn(),
-    insert : jest.fn(),
-    update : jest.fn(),
-    remove : jest.fn()
+    get: jest.fn(() => returnValues.get),
+    findAll: jest.fn(() => returnValues.findAll),
+    insert: jest.fn(() => returnValues.insert),
+    update: jest.fn(() => returnValues.update),
+    remove: jest.fn(() => returnValues.remove)
   };
-}
+};


### PR DESCRIPTION
Creates a new section and page when a questionnaire is created. 

We realised while building the eq-author front-end that this is an implicit requirement when creating a questionnaire, and so the API should assume the responsibility rather than have the front-end make multiple sequential requests.