### PR TITLE
Change api to return objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^4.0.0",
-    "eq-author-graphql-schema": "https://github.com/ONSdigital/eq-author-graphql-schema.git#b73c17a",
+    "eq-author-graphql-schema": "ONSdigital/eq-author-graphql-schema#f0306e3",
     "express": "^4.15.3",
     "graphql": "^0.9.6",
     "graphql-relay": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^4.0.0",
-    "eq-author-graphql-schema": "https://github.com/ONSdigital/eq-author-graphql-schema.git#replace-id-with-entities",
+    "eq-author-graphql-schema": "https://github.com/ONSdigital/eq-author-graphql-schema.git#b73c17a",
     "express": "^4.15.3",
     "graphql": "^0.9.6",
     "graphql-relay": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^4.0.0",
-    "eq-author-graphql-schema": "https://github.com/ONSdigital/eq-author-graphql-schema.git#766717f60e1efb38ee54d4643ef1d17828d3c5e6",
+    "eq-author-graphql-schema": "https://github.com/ONSdigital/eq-author-graphql-schema.git#replace-id-with-entities",
     "express": "^4.15.3",
     "graphql": "^0.9.6",
     "graphql-relay": "^0.5.2",

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -110,14 +110,16 @@ const Resolvers = {
 
   QuestionPage: {
     answers: ({ id }, args, ctx) =>
-      ctx.repositories.Answer.findAll({ QuestionPageId: id })
+      ctx.repositories.Answer.findAll({ QuestionPageId: id }),
+    section: ({ sectionId }, args, ctx) =>
+      ctx.repositories.Section.get(sectionId)
   },
 
   Answer: {
     __resolveType: ({ type }) =>
       includes(["Checkbox", "Radio"], type)
-    ? "MultipleChoiceAnswer"
-      : "BasicAnswer"
+        ? "MultipleChoiceAnswer"
+        : "BasicAnswer"
   },
 
   BasicAnswer: {

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -1,4 +1,4 @@
-const { merge } = require("lodash");
+const { merge, includes } = require("lodash");
 
 const Resolvers = {
   Query: {
@@ -99,7 +99,9 @@ const Resolvers = {
 
   Section: {
     pages: (section, args, ctx) =>
-      ctx.repositories.Page.findAll({ SectionId: section.id })
+      ctx.repositories.Page.findAll({ SectionId: section.id }),
+    questionnaire: (section, args, ctx) =>
+      ctx.repositories.Questionnaire.get(section.questionnaireId)
   },
 
   Page: {
@@ -112,20 +114,22 @@ const Resolvers = {
   },
 
   Answer: {
-    __resolveType: ({ type }) => {
-      switch (type) {
-        case "Checkbox":
-        case "Radio":
-          return "MultipleChoiceAnswer";
-        default:
-          return "BasicAnswer";
-      }
-    }
+    __resolveType: ({ type }) =>
+      includes(["Checkbox", "Radio"], type)
+    ? "MultipleChoiceAnswer"
+      : "BasicAnswer"
+  },
+
+  BasicAnswer: {
+    questionPage: (answer, args, ctx) =>
+      ctx.repositories.QuestionPage.get(answer.questionPageId)
   },
 
   MultipleChoiceAnswer: {
-    options: ({ id }, args, ctx) =>
-      ctx.repositories.Option.findAll({ AnswerId: id })
+    questionPage: (answer, args, ctx) =>
+      ctx.repositories.QuestionPage.get(answer.questionPageId),
+    options: (answer, args, ctx) =>
+      ctx.repositories.Option.findAll({ AnswerId: answer.id })
   }
 };
 

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -132,6 +132,10 @@ const Resolvers = {
       ctx.repositories.QuestionPage.get(answer.questionPageId),
     options: (answer, args, ctx) =>
       ctx.repositories.Option.findAll({ AnswerId: answer.id })
+  },
+
+  Option: {
+    answer: ({ answerId }, args, ctx) => ctx.repositories.Answer.get(answerId)
   }
 };
 

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -123,12 +123,12 @@ const Resolvers = {
   },
 
   BasicAnswer: {
-    questionPage: (answer, args, ctx) =>
+    page: (answer, args, ctx) =>
       ctx.repositories.QuestionPage.get(answer.questionPageId)
   },
 
   MultipleChoiceAnswer: {
-    questionPage: (answer, args, ctx) =>
+    page: (answer, args, ctx) =>
       ctx.repositories.QuestionPage.get(answer.questionPageId),
     options: (answer, args, ctx) =>
       ctx.repositories.Option.findAll({ AnswerId: answer.id })

--- a/tests/schema/mutations/createAnswer.test.js
+++ b/tests/schema/mutations/createAnswer.test.js
@@ -45,7 +45,7 @@ describe("createAnswer", () => {
         insert: {
           id: 1,
           type: "TextField",
-          questionPage: {
+          page: {
             id: 1
           }
         }

--- a/tests/schema/mutations/createAnswer.test.js
+++ b/tests/schema/mutations/createAnswer.test.js
@@ -27,8 +27,7 @@ describe("createAnswer", () => {
         qCode,
         label,
         type,
-        mandatory,
-        questionPageId
+        mandatory
         ... on MultipleChoiceAnswer {
           options {
             id
@@ -46,7 +45,9 @@ describe("createAnswer", () => {
         insert: {
           id: 1,
           type: "TextField",
-          questionPageId: 1
+          questionPage: {
+            id: 1
+          }
         }
       })
     };

--- a/tests/schema/mutations/createPage.test.js
+++ b/tests/schema/mutations/createPage.test.js
@@ -16,7 +16,6 @@ describe("createPage", () => {
         id,
         title,
         description,
-        sectionId
         ... on QuestionPage {
           guidance
         }

--- a/tests/schema/mutations/createQuestionPage.test.js
+++ b/tests/schema/mutations/createQuestionPage.test.js
@@ -24,8 +24,7 @@ describe("createQuestionPage", () => {
         description,
         guidance,
         type,
-        mandatory,
-        sectionId
+        mandatory
       }
     }
   `;

--- a/tests/schema/mutations/updateAnswer.test.js
+++ b/tests/schema/mutations/updateAnswer.test.js
@@ -1,8 +1,7 @@
 const executeQuery = require("../../utils/executeQuery");
 const mockRepository = require("../../utils/mockRepository");
 
-describe("updateAnswer" , () => {
-
+describe("updateAnswer", () => {
   const updateAnswer = `
     mutation UpdateAnswer(
       $id: Int!,
@@ -29,7 +28,6 @@ describe("updateAnswer" , () => {
         label,
         type
         mandatory
-        questionPageId
       }
     }
   `;
@@ -38,8 +36,8 @@ describe("updateAnswer" , () => {
 
   beforeEach(() => {
     repositories = {
-      Answer : mockRepository()
-    }
+      Answer: mockRepository()
+    };
   });
 
   it("should allow update of Answer", async () => {

--- a/tests/schema/mutations/updatePage.test.js
+++ b/tests/schema/mutations/updatePage.test.js
@@ -16,7 +16,6 @@ describe("updatePage", () => {
         id,
         title,
         description,
-        sectionId
         ... on QuestionPage {
           guidance
         }

--- a/tests/schema/mutations/updateQuestionPage.test.js
+++ b/tests/schema/mutations/updateQuestionPage.test.js
@@ -24,8 +24,7 @@ describe("updateQuestionPage", () => {
         description,
         guidance,
         type,
-        mandatory,
-        sectionId
+        mandatory
       }
     }
   `;

--- a/tests/schema/queries/answer.test.js
+++ b/tests/schema/queries/answer.test.js
@@ -1,8 +1,7 @@
 const executeQuery = require("../../utils/executeQuery");
 const mockRepository = require("../../utils/mockRepository");
 
-describe("answer query" , () => {
-
+describe("answer query", () => {
   const answer = `
     query GetAnswer($id: Int!) {
       answer(id: $id) {
@@ -12,7 +11,9 @@ describe("answer query" , () => {
         label,
         mandatory,
         type,
-        questionPageId
+        questionPage {
+          id
+        }
       }
     }
   `;
@@ -22,8 +23,8 @@ describe("answer query" , () => {
 
   beforeEach(() => {
     repositories = {
-      Answer : mockRepository()
-    }
+      Answer: mockRepository()
+    };
   });
 
   it("should fetch answer by id", async () => {

--- a/tests/schema/queries/answer.test.js
+++ b/tests/schema/queries/answer.test.js
@@ -11,7 +11,7 @@ describe("answer query", () => {
         label,
         mandatory,
         type,
-        questionPage {
+        page {
           id
         }
       }

--- a/tests/schema/queries/option.test.js
+++ b/tests/schema/queries/option.test.js
@@ -1,0 +1,59 @@
+const executeQuery = require("../../utils/executeQuery");
+const mockRepository = require("../../utils/mockRepository");
+
+describe("option query", () => {
+  const option = `
+    query GetOption($id: Int!) {
+      option(id: $id) {
+        id,
+        description
+      }
+    }
+  `;
+
+  const optionWithAnswer = `
+    query GetOption($id: Int!) {
+      option(id: $id) {
+        id,
+        answer {
+          id
+        }
+      }
+    }
+  `;
+
+  let repositories;
+  const id = 1;
+  const answerId = 2;
+
+  beforeEach(() => {
+    repositories = {
+      Option: mockRepository({
+        get: {
+          id,
+          answerId
+        }
+      }),
+      Answer: mockRepository()
+    };
+  });
+
+  it("should fetch option by id", async () => {
+    const result = await executeQuery(option, { id }, { repositories });
+
+    expect(result.errors).toBeUndefined();
+    expect(repositories.Option.get).toHaveBeenCalledWith(id);
+  });
+
+  it("should have an association with Answer", async () => {
+    const result = await executeQuery(
+      optionWithAnswer,
+      { id },
+      { repositories }
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(repositories.Option.get).toHaveBeenCalledWith(id);
+    expect(repositories.Answer.get).toHaveBeenCalledWith(answerId);
+  });
+});

--- a/tests/schema/queries/page.test.js
+++ b/tests/schema/queries/page.test.js
@@ -5,9 +5,15 @@ describe("Page query", () => {
   const page = `
     query GetPage($id: Int!) {
       page(id: $id) {
+        id
+      }
+    }
+  `;
+
+  const pageWithSection = `
+    query GetPage($id: Int!) {
+      page(id: $id) {
         id,
-        title,
-        description,
         section {
           id
         }
@@ -16,12 +22,20 @@ describe("Page query", () => {
   `;
 
   const id = 1;
+  const sectionId = 2;
   let repositories;
 
   beforeEach(() => {
     repositories = {
-      Page: mockRepository(),
-      QuestionPage: mockRepository()
+      Page: mockRepository({
+        get: {
+          id,
+          sectionId,
+          pageType: "QuestionPage"
+        }
+      }),
+      QuestionPage: mockRepository(),
+      Section: mockRepository()
     };
   });
 
@@ -31,5 +45,17 @@ describe("Page query", () => {
     expect(result.errors).toBeUndefined();
     expect(repositories.Page.get).toHaveBeenCalledWith(id);
     expect(repositories.QuestionPage.findAll).not.toHaveBeenCalled();
+  });
+
+  it("should have association with Section", async () => {
+    const result = await executeQuery(
+      pageWithSection,
+      { id },
+      { repositories }
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(repositories.Page.get).toHaveBeenCalledWith(id);
+    expect(repositories.Section.get).toHaveBeenCalledWith(sectionId);
   });
 });

--- a/tests/schema/queries/page.test.js
+++ b/tests/schema/queries/page.test.js
@@ -8,7 +8,9 @@ describe("Page query", () => {
         id,
         title,
         description,
-        sectionId
+        section {
+          id
+        }
       }
     }
   `;

--- a/tests/schema/queries/questionPage.test.js
+++ b/tests/schema/queries/questionPage.test.js
@@ -11,7 +11,9 @@ describe("QuestionPage query", () => {
         guidance,
         type,
         mandatory,
-        sectionId
+        section {
+          id
+        }
       }
     }
   `;

--- a/tests/schema/queries/questionPage.test.js
+++ b/tests/schema/queries/questionPage.test.js
@@ -6,11 +6,6 @@ describe("QuestionPage query", () => {
     query GetQuestionPage($id: Int!) {
       questionPage(id: $id) {
         id,
-        title,
-        description,
-        guidance,
-        type,
-        mandatory,
         section {
           id
         }
@@ -29,13 +24,31 @@ describe("QuestionPage query", () => {
     }
   `;
 
+  const questionPageWithSection = `
+  query GetQuestionPageWithSection($id: Int!) {
+    questionPage(id: $id) {
+      id,
+      section {
+        id
+      }
+    }
+  }
+  `;
+
   const id = 1;
+  const sectionId = 1;
   let repositories;
 
   beforeEach(() => {
     repositories = {
-      QuestionPage: mockRepository(),
-      Answer: mockRepository()
+      QuestionPage: mockRepository({
+        get: {
+          id,
+          sectionId
+        }
+      }),
+      Answer: mockRepository(),
+      Section: mockRepository()
     };
   });
 
@@ -44,12 +57,9 @@ describe("QuestionPage query", () => {
 
     expect(result.errors).toBeUndefined();
     expect(repositories.QuestionPage.get).toHaveBeenCalledWith(id);
-    expect(repositories.Answer.findAll).not.toHaveBeenCalled();
   });
 
   it("should have an association with Answer", async () => {
-    repositories.QuestionPage.get.mockImplementation(() => ({ id }));
-
     const result = await executeQuery(
       questionPageWithAnswers,
       { id },
@@ -61,5 +71,17 @@ describe("QuestionPage query", () => {
     expect(repositories.Answer.findAll).toHaveBeenCalledWith({
       QuestionPageId: id
     });
+  });
+
+  it("should have association with Section", async () => {
+    const result = await executeQuery(
+      questionPageWithSection,
+      { id },
+      { repositories }
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(repositories.QuestionPage.get).toHaveBeenCalledWith(id);
+    expect(repositories.Section.get).toHaveBeenCalledWith(sectionId);
   });
 });

--- a/tests/schema/queries/questionnaire.test.js
+++ b/tests/schema/queries/questionnaire.test.js
@@ -5,18 +5,13 @@ describe("questionnaire query", () => {
   const questionnaire = `
     query GetQuestionnaire($id : Int!) {
       questionnaire(id: $id) {
-        id,
-        title,
-        description,
-        navigation,
-        legalBasis,
-        theme
+        id
       }
     }
   `;
 
-  const questionnaireWithPages = `
-    query GetQuestionnaireWithPages($id : Int!) {
+  const questionnaireWithSections = `
+    query GetQuestionnaireWithSections($id : Int!) {
       questionnaire(id: $id) {
         id,
         sections {
@@ -31,7 +26,9 @@ describe("questionnaire query", () => {
 
   beforeEach(() => {
     repositories = {
-      Questionnaire: mockRepository(),
+      Questionnaire: mockRepository({
+        get: { id }
+      }),
       Section: mockRepository()
     };
   });
@@ -45,10 +42,8 @@ describe("questionnaire query", () => {
   });
 
   it("should have an association with Sections", async () => {
-    repositories.Questionnaire.get.mockImplementation(() => ({ id }));
-
     const result = await executeQuery(
-      questionnaireWithPages,
+      questionnaireWithSections,
       { id },
       { repositories }
     );

--- a/tests/schema/queries/section.test.js
+++ b/tests/schema/queries/section.test.js
@@ -6,7 +6,6 @@ describe("Section query", () => {
     query GetSection($id: Int!) {
       section(id: $id) {
         id,
-        title,
         description
       }
     }
@@ -16,8 +15,6 @@ describe("Section query", () => {
     query GetSection($id: Int!) {
       section(id: $id) {
         id,
-        title,
-        description,
         pages {
           id
         }
@@ -25,13 +22,32 @@ describe("Section query", () => {
     }
   `;
 
+  const sectionWithQuestionnaire = `
+    query GetSection($id: Int!) {
+      section(id: $id) {
+        id,
+        questionnaire {
+          id
+        }
+      }
+    }
+  `;
+
   const id = 1;
+  const questionnaireId = 2;
+
   let repositories;
 
   beforeEach(() => {
     repositories = {
-      Section: mockRepository(),
-      Page: mockRepository()
+      Section: mockRepository({
+        get: {
+          id,
+          questionnaireId
+        }
+      }),
+      Page: mockRepository(),
+      Questionnaire: mockRepository()
     };
   });
 
@@ -44,11 +60,6 @@ describe("Section query", () => {
   });
 
   it("should have an association with Pages", async () => {
-    repositories.Section.get.mockImplementation(() => ({
-      id,
-      title: "test section title"
-    }));
-
     const result = await executeQuery(
       sectionWithPages,
       { id },
@@ -58,5 +69,19 @@ describe("Section query", () => {
     expect(result.errors).toBeUndefined();
     expect(repositories.Section.get).toHaveBeenCalledWith(id);
     expect(repositories.Page.findAll).toHaveBeenCalledWith({ SectionId: id });
+  });
+
+  it("should have an association with Questionnaire", async () => {
+    const result = await executeQuery(
+      sectionWithQuestionnaire,
+      { id },
+      { repositories }
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(repositories.Section.get).toHaveBeenCalledWith(id);
+    expect(repositories.Questionnaire.get).toHaveBeenCalledWith(
+      questionnaireId
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,9 +891,9 @@ end-of-stream@1.0.0:
   dependencies:
     once "~1.3.0"
 
-"eq-author-graphql-schema@https://github.com/ONSdigital/eq-author-graphql-schema.git#replace-id-with-entities":
+"eq-author-graphql-schema@https://github.com/ONSdigital/eq-author-graphql-schema.git#b73c17a":
   version "1.0.0"
-  resolved "https://github.com/ONSdigital/eq-author-graphql-schema.git#b2b5347835f1dc5425555b09395bd44c2da535f2"
+  resolved "https://github.com/ONSdigital/eq-author-graphql-schema.git#b73c17a"
 
 errno@^0.1.4:
   version "0.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,9 +891,9 @@ end-of-stream@1.0.0:
   dependencies:
     once "~1.3.0"
 
-"eq-author-graphql-schema@https://github.com/ONSdigital/eq-author-graphql-schema.git#766717f60e1efb38ee54d4643ef1d17828d3c5e6":
+"eq-author-graphql-schema@https://github.com/ONSdigital/eq-author-graphql-schema.git#replace-id-with-entities":
   version "1.0.0"
-  resolved "https://github.com/ONSdigital/eq-author-graphql-schema.git#766717f60e1efb38ee54d4643ef1d17828d3c5e6"
+  resolved "https://github.com/ONSdigital/eq-author-graphql-schema.git#b2b5347835f1dc5425555b09395bd44c2da535f2"
 
 errno@^0.1.4:
   version "0.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,9 +891,9 @@ end-of-stream@1.0.0:
   dependencies:
     once "~1.3.0"
 
-"eq-author-graphql-schema@https://github.com/ONSdigital/eq-author-graphql-schema.git#b73c17a":
+eq-author-graphql-schema@ONSdigital/eq-author-graphql-schema#f0306e3:
   version "1.0.0"
-  resolved "https://github.com/ONSdigital/eq-author-graphql-schema.git#b73c17a"
+  resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/f0306e3"
 
 errno@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
### What is the context of this PR?
This PR removes foreign key details from leaking into the GraphQL API, by updating the resolvers to return references to the actual entities.

In practice what this allows you to do is browse the API as a graph of objects, so you can go in both directions, up and down the tree.

So for example, you can now do things like:

```
{
  questionnaire(id: 1) {
     title
     sections {
       id
       questionnaire {
          title
       }
     }
  }
}

```

in the above example, both `title` attributes should be equal.

### How to review 
This PR is not ready for merge until the schema and the front-end changes have been completed.
They will be worked on in separate PRs.
