### PR TITLE
Ensure eq-survey-graphql-schema is upgraded before application starts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "app.js",
   "license": "MIT",
   "scripts": {
+    "prestart": "yarn upgrade eq-author-graphql-schema",
     "start": "yarn knex -- migrate:latest && nodemon",
     "start:dev": "yarn knex -- migrate:latest && nodemon --inspect=0.0.0.0:5858",
     "lint": "eslint .",


### PR DESCRIPTION
### What is the context of this PR?
When CF launches the application it runs the default start script.
We need to ensure that the `yarn upgrade eq-author-graphql-schema` command is run before starting.

### How to review 
Should not affect application behaviour.
