### PR TITLE
accept input types only for mutations, fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^4.0.0",
-    "eq-author-graphql-schema": "ONSdigital/eq-author-graphql-schema#ff87872",
+    "eq-author-graphql-schema": "ONSdigital/eq-author-graphql-schema#e5caa74",
     "express": "^4.15.3",
     "graphql": "^0.9.6",
     "graphql-iso-date": "^3.3.0",

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -3,8 +3,6 @@ const { includes } = require("lodash");
 
 const getId = args => args.newId || args.id;
 const getNewId = entity => entity.id.toString(10);
-const getInputArgs = args => args.input || args;
-const getIdFromArgs = args => getInputArgs(args).id;
 
 const Resolvers = {
   Query: {
@@ -22,7 +20,7 @@ const Resolvers = {
   Mutation: {
     createQuestionnaire: async (root, args, ctx) => {
       const questionnaire = await ctx.repositories.Questionnaire.insert(
-        getInputArgs(args)
+        args.input
       );
       const section = {
         title: "",
@@ -30,16 +28,16 @@ const Resolvers = {
         questionnaireId: questionnaire.id
       };
 
-      await Resolvers.Mutation.createSection(root, section, ctx);
+      await Resolvers.Mutation.createSection(root, { input: section }, ctx);
       return questionnaire;
     },
     updateQuestionnaire: (_, args, ctx) =>
-      ctx.repositories.Questionnaire.update(getInputArgs(args)),
+      ctx.repositories.Questionnaire.update(args.input),
     deleteQuestionnaire: (_, args, ctx) =>
-      ctx.repositories.Questionnaire.remove(getIdFromArgs(args)),
+      ctx.repositories.Questionnaire.remove(args.input.id),
 
     createSection: async (root, args, ctx) => {
-      const section = await ctx.repositories.Section.insert(getInputArgs(args));
+      const section = await ctx.repositories.Section.insert(args.input);
       const page = {
         pageType: "QuestionPage",
         title: "",
@@ -51,26 +49,23 @@ const Resolvers = {
       return section;
     },
     updateSection: (_, args, ctx) =>
-      ctx.repositories.Section.update(getInputArgs(args)),
+      ctx.repositories.Section.update(args.input),
     deleteSection: (_, args, ctx) =>
-      ctx.repositories.Section.remove(getIdFromArgs(args)),
+      ctx.repositories.Section.remove(args.input.id),
 
-    createPage: (root, args, ctx) =>
-      ctx.repositories.Page.insert(getInputArgs(args)),
-    updatePage: (_, args, ctx) =>
-      ctx.repositories.Page.update(getInputArgs(args)),
-    deletePage: (_, args, ctx) =>
-      ctx.repositories.Page.remove(getIdFromArgs(args)),
+    createPage: (root, args, ctx) => ctx.repositories.Page.insert(args.input),
+    updatePage: (_, args, ctx) => ctx.repositories.Page.update(args.input),
+    deletePage: (_, args, ctx) => ctx.repositories.Page.remove(args.input.id),
 
     createQuestionPage: (root, args, ctx) =>
-      ctx.repositories.QuestionPage.insert(getInputArgs(args)),
+      ctx.repositories.QuestionPage.insert(args.input),
     updateQuestionPage: (_, args, ctx) =>
-      ctx.repositories.QuestionPage.update(getInputArgs(args)),
+      ctx.repositories.QuestionPage.update(args.input),
     deleteQuestionPage: (_, args, ctx) =>
-      ctx.repositories.QuestionPage.remove(getIdFromArgs(args)),
+      ctx.repositories.QuestionPage.remove(args.input.id),
 
     createAnswer: async (root, args, ctx) => {
-      const answer = await ctx.repositories.Answer.insert(getInputArgs(args));
+      const answer = await ctx.repositories.Answer.insert(args.input);
 
       if (answer.type === "Checkbox" || answer.type === "Radio") {
         const defaultOptions = [];
@@ -89,7 +84,7 @@ const Resolvers = {
         }
 
         const promises = defaultOptions.map(it =>
-          Resolvers.Mutation.createOption(root, it, ctx)
+          Resolvers.Mutation.createOption(root, { input: it }, ctx)
         );
 
         await Promise.all(promises);
@@ -97,17 +92,15 @@ const Resolvers = {
 
       return answer;
     },
-    updateAnswer: (_, args, ctx) =>
-      ctx.repositories.Answer.update(getInputArgs(args)),
+    updateAnswer: (_, args, ctx) => ctx.repositories.Answer.update(args.input),
     deleteAnswer: (_, args, ctx) =>
-      ctx.repositories.Answer.remove(getIdFromArgs(args)),
+      ctx.repositories.Answer.remove(args.input.id),
 
     createOption: (root, args, ctx) =>
-      ctx.repositories.Option.insert(getInputArgs(args)),
-    updateOption: (_, args, ctx) =>
-      ctx.repositories.Option.update(getInputArgs(args)),
+      ctx.repositories.Option.insert(args.input),
+    updateOption: (_, args, ctx) => ctx.repositories.Option.update(args.input),
     deleteOption: (_, args, ctx) =>
-      ctx.repositories.Option.remove(getIdFromArgs(args))
+      ctx.repositories.Option.remove(args.input.id)
   },
 
   Questionnaire: {

--- a/tests/schema/mutations/createAnswer.test.js
+++ b/tests/schema/mutations/createAnswer.test.js
@@ -3,24 +3,8 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("createAnswer", () => {
   const createAnswer = `
-    mutation CreateAnswer(
-      $description: String,
-      $guidance: String,
-      $qCode: String,
-      $label: String,
-      $type: AnswerType!,
-      $mandatory: Boolean!,
-      $questionPageId: Int!
-    ) {
-      createAnswer(
-        description: $description,
-        guidance: $guidance,
-        qCode: $qCode,
-        label: $label,
-        type: $type,
-        mandatory: $mandatory,
-        questionPageId: $questionPageId
-      ) {
+    mutation CreateAnswer($input: CreateAnswerInput!) {
+      createAnswer(input: $input) {
         id,
         description,
         guidance,
@@ -43,10 +27,10 @@ describe("createAnswer", () => {
     repositories = {
       Answer: mockRepository({
         insert: {
-          id: 1,
+          id: "1",
           type: "TextField",
           page: {
-            id: 1
+            id: "1"
           }
         }
       })
@@ -54,19 +38,22 @@ describe("createAnswer", () => {
   });
 
   it("should allow creation of Answer", async () => {
-    const fixture = {
-      title: "Test answer",
+    const input = {
       description: "Test answer description",
       guidance: "Test answer guidance",
       type: "TextField",
       mandatory: false,
-      questionPageId: 1
+      questionPageId: "1"
     };
 
-    const result = await executeQuery(createAnswer, fixture, { repositories });
+    const result = await executeQuery(
+      createAnswer,
+      { input },
+      { repositories }
+    );
 
     expect(result.errors).toBeUndefined();
-    expect(repositories.Answer.insert).toHaveBeenCalled();
+    expect(repositories.Answer.insert).toHaveBeenCalledWith(input);
   });
 
   describe("multiple choice answers", () => {
@@ -85,18 +72,19 @@ describe("createAnswer", () => {
     const createFixture = answerType => {
       repositories.Answer = mockRepository({
         insert: {
-          id: 1,
+          id: "1",
           type: answerType,
-          questionPageId: 1
+          questionPageId: "1"
         }
       });
       return {
-        title: "Test answer",
-        description: "Test answer description",
-        guidance: "Test answer guidance",
-        type: answerType,
-        mandatory: false,
-        questionPageId: 1
+        input: {
+          description: "Test answer description",
+          guidance: "Test answer guidance",
+          type: answerType,
+          mandatory: false,
+          questionPageId: "1"
+        }
       };
     };
 

--- a/tests/schema/mutations/createPage.test.js
+++ b/tests/schema/mutations/createPage.test.js
@@ -3,16 +3,8 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("createPage", () => {
   const createPage = `
-    mutation CreatePage(
-      $title: String!,
-      $description: String,
-      $sectionId: Int!
-    ) {
-      createPage(
-        title: $title,
-        description: $description,
-        sectionId: $sectionId
-      ) {
+    mutation CreatePage($input: CreatePageInput!) {
+      createPage(input: $input) {
         id,
         title,
         description,
@@ -32,15 +24,15 @@ describe("createPage", () => {
   });
 
   it("should allow creation of Page", async () => {
-    const fixture = {
+    const input = {
       title: "Test page",
       description: "Test page description",
-      sectionId: 1
+      sectionId: "1"
     };
 
-    const result = await executeQuery(createPage, fixture, { repositories });
+    const result = await executeQuery(createPage, { input }, { repositories });
 
     expect(result.errors).toBeUndefined();
-    expect(repositories.Page.insert).toHaveBeenCalled();
+    expect(repositories.Page.insert).toHaveBeenCalledWith(input);
   });
 });

--- a/tests/schema/mutations/createQuestionPage.test.js
+++ b/tests/schema/mutations/createQuestionPage.test.js
@@ -3,18 +3,8 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("createQuestionPage", () => {
   const createQuestionPage = `
-    mutation CreateQuestionPage(
-      $title: String!,
-      $description: String!,
-      $guidance: String!,
-      $sectionId: Int!
-    ) {
-      createQuestionPage(
-        title: $title,
-        description: $description,
-        guidance: $guidance,
-        sectionId: $sectionId
-      ) {
+    mutation CreateQuestionPage($input: CreateQuestionPageInput!) {
+      createQuestionPage(input: $input) {
         id,
         title,
         description,
@@ -32,18 +22,20 @@ describe("createQuestionPage", () => {
   });
 
   it("should allow creation of Question", async () => {
-    const fixture = {
+    const input = {
       title: "Test question",
       description: "Test question description",
       guidance: "Test question guidance",
-      sectionId: 1
+      sectionId: "1"
     };
 
-    const result = await executeQuery(createQuestionPage, fixture, {
-      repositories
-    });
+    const result = await executeQuery(
+      createQuestionPage,
+      { input },
+      { repositories }
+    );
 
     expect(result.errors).toBeUndefined();
-    expect(repositories.QuestionPage.insert).toHaveBeenCalled();
+    expect(repositories.QuestionPage.insert).toHaveBeenCalledWith(input);
   });
 });

--- a/tests/schema/mutations/createQuestionnaire.test.js
+++ b/tests/schema/mutations/createQuestionnaire.test.js
@@ -3,22 +3,8 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("createQuestionnaire", () => {
   const createQuestionnaire = `
-    mutation CreateQuestionnaire(
-      $title: String!,
-      $description: String!,
-      $theme: String!,
-      $legalBasis: LegalBasis!,
-      $navigation: Boolean,
-      $surveyId : String!
-    ) {
-      createQuestionnaire(
-        title: $title,
-        description: $description,
-        theme: $theme,
-        legalBasis: $legalBasis,
-        navigation: $navigation,
-        surveyId : $surveyId
-      ) {
+    mutation CreateQuestionnaire($input: CreateQuestionnaireInput!) {
+      createQuestionnaire(input: $input) {
         id,
         title,
         description,
@@ -31,8 +17,8 @@ describe("createQuestionnaire", () => {
 
   let repositories;
 
-  const QUESTIONNAIRE_ID = 123;
-  const SECTION_ID = 456;
+  const QUESTIONNAIRE_ID = "123";
+  const SECTION_ID = "456";
 
   beforeEach(() => {
     repositories = {
@@ -47,7 +33,7 @@ describe("createQuestionnaire", () => {
   });
 
   it("should allow creation of Questionnaire", async () => {
-    const fixture = {
+    const input = {
       title: "Test questionnaire",
       description: "This is a test questionnaire",
       theme: "test theme",
@@ -56,14 +42,16 @@ describe("createQuestionnaire", () => {
       surveyId: "abc"
     };
 
-    const result = await executeQuery(createQuestionnaire, fixture, {
-      repositories
-    });
+    const result = await executeQuery(
+      createQuestionnaire,
+      { input },
+      { repositories }
+    );
 
     expect(result.errors).toBeUndefined();
     expect(result.data.createQuestionnaire.id).toBe(QUESTIONNAIRE_ID);
 
-    expect(repositories.Questionnaire.insert).toHaveBeenCalled();
+    expect(repositories.Questionnaire.insert).toHaveBeenCalledWith(input);
     expect(repositories.Section.insert).toHaveBeenCalledWith(
       expect.objectContaining({ questionnaireId: QUESTIONNAIRE_ID })
     );

--- a/tests/schema/mutations/createSection.test.js
+++ b/tests/schema/mutations/createSection.test.js
@@ -3,16 +3,8 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("createSection", () => {
   const createSection = `
-    mutation CreateSection(
-      $title: String!,
-      $description: String,
-      $questionnaireId: Int!
-    ) {
-      createSection(
-        title: $title,
-        description: $description,
-        questionnaireId: $questionnaireId
-      ) {
+    mutation CreateSection($input: CreateSectionInput!) {
+      createSection(input: $input) {
         id,
         title
       }
@@ -20,8 +12,8 @@ describe("createSection", () => {
   `;
 
   let repositories;
-  const QUESTIONNAIRE_ID = 123;
-  const SECTION_ID = 456;
+  const QUESTIONNAIRE_ID = "123";
+  const SECTION_ID = "456";
 
   beforeEach(() => {
     repositories = {
@@ -33,19 +25,23 @@ describe("createSection", () => {
   });
 
   it("should allow creation of Section", async () => {
-    const fixture = {
+    const input = {
       title: "Test section",
       description: "Test section description",
       questionnaireId: QUESTIONNAIRE_ID
     };
 
-    const result = await executeQuery(createSection, fixture, { repositories });
+    const result = await executeQuery(
+      createSection,
+      { input },
+      { repositories }
+    );
 
     expect(result.errors).toBeUndefined();
     expect(result.data.createSection.id).toBe(SECTION_ID);
 
     expect(repositories.Section.insert).toHaveBeenCalledWith(
-      expect.objectContaining(fixture)
+      expect.objectContaining(input)
     );
 
     expect(repositories.Page.insert).toHaveBeenCalledWith(

--- a/tests/schema/mutations/deleteAnswer.test.js
+++ b/tests/schema/mutations/deleteAnswer.test.js
@@ -1,11 +1,10 @@
 const executeQuery = require("../../utils/executeQuery");
 const mockRepository = require("../../utils/mockRepository");
 
-describe("deleteAnswer" , () => {
-
+describe("deleteAnswer", () => {
   const deleteAnswer = `
-    mutation DeleteAnswer($id:Int!) {
-      deleteAnswer(id:$id){
+    mutation DeleteAnswer($input:DeleteAnswerInput!) {
+      deleteAnswer(input:$input){
         id
       }
     }
@@ -15,14 +14,19 @@ describe("deleteAnswer" , () => {
 
   beforeEach(() => {
     repositories = {
-      Answer : mockRepository()
-    }
+      Answer: mockRepository()
+    };
   });
 
   it("should allow deletion of Answer", async () => {
-    const result = await executeQuery(deleteAnswer, { id : 1 }, { repositories });
+    const input = { id: "1" };
+    const result = await executeQuery(
+      deleteAnswer,
+      { input },
+      { repositories }
+    );
 
     expect(result.errors).toBeUndefined();
-    expect(repositories.Answer.remove).toHaveBeenCalledWith(1);
+    expect(repositories.Answer.remove).toHaveBeenCalledWith(input.id);
   });
 });

--- a/tests/schema/mutations/deletePage.test.js
+++ b/tests/schema/mutations/deletePage.test.js
@@ -1,11 +1,10 @@
 const executeQuery = require("../../utils/executeQuery");
 const mockRepository = require("../../utils/mockRepository");
 
-describe("deletePage" , () => {
-
+describe("deletePage", () => {
   const deletePage = `
-    mutation DeletePage($id:Int!) {
-      deletePage(id:$id) {
+    mutation DeletePage($input:DeletePageInput!) {
+      deletePage(input:$input) {
         id
       }
     }
@@ -15,14 +14,15 @@ describe("deletePage" , () => {
 
   beforeEach(() => {
     repositories = {
-      Page : mockRepository()
-    }
+      Page: mockRepository()
+    };
   });
 
   it("should allow deletion of Page", async () => {
-    const result = await executeQuery(deletePage, { id : 1 }, { repositories });
+    const input = { id: "1" };
+    const result = await executeQuery(deletePage, { input }, { repositories });
 
     expect(result.errors).toBeUndefined();
-    expect(repositories.Page.remove).toHaveBeenCalledWith(1);
+    expect(repositories.Page.remove).toHaveBeenCalledWith(input.id);
   });
 });

--- a/tests/schema/mutations/deleteQuestionPage.test.js
+++ b/tests/schema/mutations/deleteQuestionPage.test.js
@@ -1,11 +1,10 @@
 const executeQuery = require("../../utils/executeQuery");
 const mockRepository = require("../../utils/mockRepository");
 
-describe("deleteQuestionPage" , () => {
-
+describe("deleteQuestionPage", () => {
   const deleteQuestionPage = `
-    mutation DeleteQuestionPage($id:Int!) {
-      deleteQuestionPage(id:$id){
+    mutation DeleteQuestionPage($input:DeleteQuestionPageInput!) {
+      deleteQuestionPage(input:$input){
         id
       }
     }
@@ -15,14 +14,19 @@ describe("deleteQuestionPage" , () => {
 
   beforeEach(() => {
     repositories = {
-      QuestionPage : mockRepository()
-    }
+      QuestionPage: mockRepository()
+    };
   });
 
   it("should allow deletion of Question", async () => {
-    const result = await executeQuery(deleteQuestionPage, { id : 1 }, { repositories });
+    const input = { id: "1" };
+    const result = await executeQuery(
+      deleteQuestionPage,
+      { input },
+      { repositories }
+    );
 
     expect(result.errors).toBeUndefined();
-    expect(repositories.QuestionPage.remove).toHaveBeenCalledWith(1);
+    expect(repositories.QuestionPage.remove).toHaveBeenCalledWith(input.id);
   });
 });

--- a/tests/schema/mutations/deleteQuestionnaire.test.js
+++ b/tests/schema/mutations/deleteQuestionnaire.test.js
@@ -1,11 +1,10 @@
 const executeQuery = require("../../utils/executeQuery");
 const mockRepository = require("../../utils/mockRepository");
 
-describe("deleteQuestionnaire" , () => {
-
+describe("deleteQuestionnaire", () => {
   const deleteQuestionnaire = `
-    mutation DeleteQuestionnaire($id:Int!) {
-      deleteQuestionnaire(id:$id){
+    mutation DeleteQuestionnaire($input:DeleteQuestionnaireInput!) {
+      deleteQuestionnaire(input:$input){
         id
       }
     }
@@ -15,14 +14,19 @@ describe("deleteQuestionnaire" , () => {
 
   beforeEach(() => {
     repositories = {
-      Questionnaire : mockRepository()
-    }
+      Questionnaire: mockRepository()
+    };
   });
 
   it("should allow deletion of Questionnaire", async () => {
-    const result = await executeQuery(deleteQuestionnaire, { id : 1 }, { repositories });
+    const input = { id: "1" };
+    const result = await executeQuery(
+      deleteQuestionnaire,
+      { input },
+      { repositories }
+    );
 
     expect(result.errors).toBeUndefined();
-    expect(repositories.Questionnaire.remove).toHaveBeenCalledWith(1);
+    expect(repositories.Questionnaire.remove).toHaveBeenCalledWith(input.id);
   });
 });

--- a/tests/schema/mutations/deleteSection.test.js
+++ b/tests/schema/mutations/deleteSection.test.js
@@ -3,8 +3,8 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("deleteSection", () => {
   const deleteSection = `
-    mutation DeleteSection($id:Int!) {
-      deleteSection(id:$id) {
+    mutation DeleteSection($input:DeleteSectionInput!) {
+      deleteSection(input:$input) {
         id
       }
     }
@@ -19,13 +19,14 @@ describe("deleteSection", () => {
   });
 
   it("should allow deletion of Section", async () => {
+    const input = { id: "1" };
     const result = await executeQuery(
       deleteSection,
-      { id: 1 },
+      { input },
       { repositories }
     );
 
     expect(result.errors).toBeUndefined();
-    expect(repositories.Section.remove).toHaveBeenCalledWith(1);
+    expect(repositories.Section.remove).toHaveBeenCalledWith(input.id);
   });
 });

--- a/tests/schema/mutations/updateAnswer.test.js
+++ b/tests/schema/mutations/updateAnswer.test.js
@@ -3,24 +3,8 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("updateAnswer", () => {
   const updateAnswer = `
-    mutation UpdateAnswer(
-      $id: Int!,
-      $description: String,
-      $guidance: String,
-      $qCode: String,
-      $label: String,
-      $type: AnswerType!,
-      $mandatory: Boolean
-    ) {
-      updateAnswer(
-        id: $id,
-        description: $description,
-        guidance: $guidance,
-        qCode: $qCode,
-        label: $label,
-        type: $type,
-        mandatory: $mandatory,
-      ) {
+    mutation UpdateAnswer($input: UpdateAnswerInput!) {
+      updateAnswer(input: $input) {
         id,
         description,
         guidance,
@@ -41,8 +25,8 @@ describe("updateAnswer", () => {
   });
 
   it("should allow update of Answer", async () => {
-    const fixture = {
-      id: 1,
+    const input = {
+      id: "1",
       description: "This is an updated answer description",
       guidance: "This is an update answer guidance",
       qCode: "123",
@@ -51,9 +35,13 @@ describe("updateAnswer", () => {
       mandatory: false
     };
 
-    const result = await executeQuery(updateAnswer, fixture, { repositories });
+    const result = await executeQuery(
+      updateAnswer,
+      { input },
+      { repositories }
+    );
 
     expect(result.errors).toBeUndefined();
-    expect(repositories.Answer.update).toHaveBeenCalled();
+    expect(repositories.Answer.update).toHaveBeenCalledWith(input);
   });
 });

--- a/tests/schema/mutations/updatePage.test.js
+++ b/tests/schema/mutations/updatePage.test.js
@@ -3,16 +3,8 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("updatePage", () => {
   const updatePage = `
-    mutation UpdatePage(
-      $id: Int!,
-      $title: String!,
-      $description: String!
-    ) {
-      updatePage(
-        id: $id,
-        title: $title,
-        description: $description,
-      ) {
+    mutation UpdatePage($input: UpdatePageInput!) {
+      updatePage(input: $input) {
         id,
         title,
         description,
@@ -32,15 +24,15 @@ describe("updatePage", () => {
   });
 
   it("should allow update of Page", async () => {
-    const fixture = {
-      id: 1,
+    const input = {
+      id: "1",
       title: "Updated page title",
       description: "This is an updated page description"
     };
 
-    const result = await executeQuery(updatePage, fixture, { repositories });
+    const result = await executeQuery(updatePage, { input }, { repositories });
 
     expect(result.errors).toBeUndefined();
-    expect(repositories.Page.update).toHaveBeenCalled();
+    expect(repositories.Page.update).toHaveBeenCalledWith(input);
   });
 });

--- a/tests/schema/mutations/updateQuestionPage.test.js
+++ b/tests/schema/mutations/updateQuestionPage.test.js
@@ -3,18 +3,8 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("updateQuestionPage", () => {
   const updateQuestionPage = `
-    mutation UpdateQuestionPage(
-      $id: Int!,
-      $title: String!,
-      $description: String!,
-      $guidance: String!
-    ) {
-      updateQuestionPage(
-        id: $id,
-        title: $title,
-        description: $description,
-        guidance: $guidance
-      ) {
+    mutation UpdateQuestionPage($input: UpdateQuestionPageInput!) {
+      updateQuestionPage(input: $input) {
         id,
         title,
         description,
@@ -32,18 +22,20 @@ describe("updateQuestionPage", () => {
   });
 
   it("should allow update of Question", async () => {
-    const fixture = {
-      id: 1,
+    const input = {
+      id: "1",
       title: "Updated question title",
       description: "This is an updated question description",
       guidance: "Updated question description"
     };
 
-    const result = await executeQuery(updateQuestionPage, fixture, {
-      repositories
-    });
+    const result = await executeQuery(
+      updateQuestionPage,
+      { input },
+      { repositories }
+    );
 
     expect(result.errors).toBeUndefined();
-    expect(repositories.QuestionPage.update).toHaveBeenCalled();
+    expect(repositories.QuestionPage.update).toHaveBeenCalledWith(input);
   });
 });

--- a/tests/schema/mutations/updateQuestionnaire.test.js
+++ b/tests/schema/mutations/updateQuestionnaire.test.js
@@ -1,25 +1,10 @@
 const executeQuery = require("../../utils/executeQuery");
 const mockRepository = require("../../utils/mockRepository");
 
-describe("updateQuestionnaire" , () => {
-
+describe("updateQuestionnaire", () => {
   const updateQuestionnaire = `
-    mutation UpdateQuestionnaire(
-      $id: Int!,
-      $title: String!,
-      $description: String!,
-      $theme: String!,
-      $legalBasis: LegalBasis!,
-      $navigation: Boolean
-    ) {
-      updateQuestionnaire(
-        id: $id,
-        title: $title,
-        description: $description,
-        theme: $theme,
-        legalBasis: $legalBasis,
-        navigation: $navigation
-      ) {
+    mutation UpdateQuestionnaire($input: UpdateQuestionnaireInput!) {
+      updateQuestionnaire(input: $input) {
         id
       }
     }
@@ -29,13 +14,13 @@ describe("updateQuestionnaire" , () => {
 
   beforeEach(() => {
     repositories = {
-      Questionnaire : mockRepository()
-    }
+      Questionnaire: mockRepository()
+    };
   });
 
   it("should allow update of Questionnaire", async () => {
-    const fixture = {
-      id: 1,
+    const input = {
+      id: "1",
       title: "Test questionnaire",
       description: "This is a test questionnaire",
       theme: "test theme",
@@ -43,9 +28,13 @@ describe("updateQuestionnaire" , () => {
       navigation: false
     };
 
-    const result = await executeQuery(updateQuestionnaire, fixture, { repositories });
+    const result = await executeQuery(
+      updateQuestionnaire,
+      { input },
+      { repositories }
+    );
 
     expect(result.errors).toBeUndefined();
-    expect(repositories.Questionnaire.update).toHaveBeenCalled();
+    expect(repositories.Questionnaire.update).toHaveBeenCalledWith(input);
   });
 });

--- a/tests/schema/mutations/updateSection.test.js
+++ b/tests/schema/mutations/updateSection.test.js
@@ -3,16 +3,8 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("updateSection", () => {
   const updateSection = `
-    mutation UpdateSection(
-      $id: Int!,
-      $title: String!,
-      $description: String!
-    ) {
-      updateSection(
-        id: $id,
-        title: $title,
-        description: $description,
-      ) {
+    mutation UpdateSection($input: UpdateSectionInput!) {
+      updateSection(input: $input) {
         id,
         title
       }
@@ -28,15 +20,19 @@ describe("updateSection", () => {
   });
 
   it("should allow update of Section", async () => {
-    const fixture = {
-      id: 1,
+    const input = {
+      id: "1",
       title: "Updated section title",
       description: "This is an updated section description"
     };
 
-    const result = await executeQuery(updateSection, fixture, { repositories });
+    const result = await executeQuery(
+      updateSection,
+      { input },
+      { repositories }
+    );
 
     expect(result.errors).toBeUndefined();
-    expect(repositories.Section.update).toHaveBeenCalled();
+    expect(repositories.Section.update).toHaveBeenCalledWith(input);
   });
 });

--- a/tests/schema/queries/answer.test.js
+++ b/tests/schema/queries/answer.test.js
@@ -3,7 +3,7 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("answer query", () => {
   const answer = `
-    query GetAnswer($id: Int!) {
+    query GetAnswer($id: ID!) {
       answer(id: $id) {
         id
       }
@@ -11,7 +11,7 @@ describe("answer query", () => {
   `;
 
   const answerWithOption = `
-    query GetAnswer($id: Int!) {
+    query GetAnswer($id: ID!) {
       answer(id: $id) {
         id,
         ... on MultipleChoiceAnswer {
@@ -24,7 +24,7 @@ describe("answer query", () => {
   `;
 
   const answerWithPage = `
-    query GetAnswer($id: Int!) {
+    query GetAnswer($id: ID!) {
       answer(id: $id) {
         id,
         page {
@@ -35,8 +35,8 @@ describe("answer query", () => {
   `;
 
   let repositories;
-  const id = 1;
-  const questionPageId = 2;
+  const id = "1";
+  const questionPageId = "2";
 
   beforeEach(() => {
     repositories = {

--- a/tests/schema/queries/option.test.js
+++ b/tests/schema/queries/option.test.js
@@ -3,7 +3,7 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("option query", () => {
   const option = `
-    query GetOption($id: Int!) {
+    query GetOption($id: ID!) {
       option(id: $id) {
         id,
         description
@@ -12,7 +12,7 @@ describe("option query", () => {
   `;
 
   const optionWithAnswer = `
-    query GetOption($id: Int!) {
+    query GetOption($id: ID!) {
       option(id: $id) {
         id,
         answer {
@@ -23,8 +23,8 @@ describe("option query", () => {
   `;
 
   let repositories;
-  const id = 1;
-  const answerId = 2;
+  const id = "1";
+  const answerId = "2";
 
   beforeEach(() => {
     repositories = {

--- a/tests/schema/queries/page.test.js
+++ b/tests/schema/queries/page.test.js
@@ -3,7 +3,7 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("Page query", () => {
   const page = `
-    query GetPage($id: Int!) {
+    query GetPage($id: ID!) {
       page(id: $id) {
         id
       }
@@ -11,7 +11,7 @@ describe("Page query", () => {
   `;
 
   const pageWithSection = `
-    query GetPage($id: Int!) {
+    query GetPage($id: ID!) {
       page(id: $id) {
         id,
         section {
@@ -21,8 +21,8 @@ describe("Page query", () => {
     }
   `;
 
-  const id = 1;
-  const sectionId = 2;
+  const id = "1";
+  const sectionId = "2";
   let repositories;
 
   beforeEach(() => {

--- a/tests/schema/queries/questionPage.test.js
+++ b/tests/schema/queries/questionPage.test.js
@@ -3,7 +3,7 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("QuestionPage query", () => {
   const questionPage = `
-    query GetQuestionPage($id: Int!) {
+    query GetQuestionPage($id: ID!) {
       questionPage(id: $id) {
         id,
         section {
@@ -14,7 +14,7 @@ describe("QuestionPage query", () => {
   `;
 
   const questionPageWithAnswers = `
-    query GetQuestionPageWithAnswers($id: Int!) {
+    query GetQuestionPageWithAnswers($id: ID!) {
       questionPage(id: $id) {
         id,
         answers {
@@ -25,7 +25,7 @@ describe("QuestionPage query", () => {
   `;
 
   const questionPageWithSection = `
-  query GetQuestionPageWithSection($id: Int!) {
+  query GetQuestionPageWithSection($id: ID!) {
     questionPage(id: $id) {
       id,
       section {
@@ -35,8 +35,8 @@ describe("QuestionPage query", () => {
   }
   `;
 
-  const id = 1;
-  const sectionId = 1;
+  const id = "1";
+  const sectionId = "1";
   let repositories;
 
   beforeEach(() => {

--- a/tests/schema/queries/questionnaire.test.js
+++ b/tests/schema/queries/questionnaire.test.js
@@ -3,7 +3,7 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("questionnaire query", () => {
   const questionnaire = `
-    query GetQuestionnaire($id : Int!) {
+    query GetQuestionnaire($id : ID!) {
       questionnaire(id: $id) {
         id
       }
@@ -11,7 +11,7 @@ describe("questionnaire query", () => {
   `;
 
   const questionnaireWithSections = `
-    query GetQuestionnaireWithSections($id : Int!) {
+    query GetQuestionnaireWithSections($id : ID!) {
       questionnaire(id: $id) {
         id,
         sections {
@@ -21,7 +21,7 @@ describe("questionnaire query", () => {
     }
   `;
 
-  const id = 1;
+  const id = "1";
   let repositories;
 
   beforeEach(() => {

--- a/tests/schema/queries/section.test.js
+++ b/tests/schema/queries/section.test.js
@@ -3,7 +3,7 @@ const mockRepository = require("../../utils/mockRepository");
 
 describe("Section query", () => {
   const section = `
-    query GetSection($id: Int!) {
+    query GetSection($id: ID!) {
       section(id: $id) {
         id,
         description
@@ -12,7 +12,7 @@ describe("Section query", () => {
   `;
 
   const sectionWithPages = `
-    query GetSection($id: Int!) {
+    query GetSection($id: ID!) {
       section(id: $id) {
         id,
         pages {
@@ -23,7 +23,7 @@ describe("Section query", () => {
   `;
 
   const sectionWithQuestionnaire = `
-    query GetSection($id: Int!) {
+    query GetSection($id: ID!) {
       section(id: $id) {
         id,
         questionnaire {
@@ -33,8 +33,8 @@ describe("Section query", () => {
     }
   `;
 
-  const id = 1;
-  const questionnaireId = 2;
+  const id = "1";
+  const questionnaireId = "2";
 
   let repositories;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,13 +944,9 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-eq-author-graphql-schema@ONSdigital/eq-author-graphql-schema#b34dc52:
+eq-author-graphql-schema@ONSdigital/eq-author-graphql-schema#e5caa74:
   version "1.0.0"
-  resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/b34dc52"
-
-eq-author-graphql-schema@ONSdigital/eq-author-graphql-schema#ff87872:
-  version "1.0.0"
-  resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/ff87872089cbfde430e3dbe9e90c1301fa01ae5d"
+  resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/e5caa744b1fe0962c21b19448531e64a42174b01"
 
 errno@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
### What is the context of this PR?
Cleans up some changes from previous PR, which were to ensure backwards compatibility

* now exclusively uses input types for mutations
* updates test to reflect `id` fields are now type `ID`

### How to review 
Run tests, sanity-check code
