### PR TITLE
Add basic HTTP logging to the API and a bit of refactoring.

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,26 +3,26 @@ const { graphqlExpress, graphiqlExpress } = require("graphql-server-express");
 const repositories = require("./repositories");
 const colors = require("colors");
 const cors = require("cors");
-const bodyParser = require('body-parser');
+const bodyParser = require("body-parser");
 const schema = require("./schema");
+const morgan = require("morgan");
 
-const {
-  EXPRESS_URL,
-  EXPRESS_PORT,
-  GRAPHIQL_ENDPOINT,
-} = require('./config/settings');
+const { PORT } = require("./config/settings");
 
 const app = express();
-app.use('/graphql', cors(), bodyParser.json(), graphqlExpress({schema: schema, context:{ repositories: repositories }}));
+app.use(morgan("tiny"));
 
-if (process.env.NODE_ENV === 'development'){
-  app.use('/graphiql', cors(), graphiqlExpress({ endpointURL: '/graphql' }))
+app.use(
+  "/graphql",
+  cors(),
+  bodyParser.json(),
+  graphqlExpress({ schema: schema, context: { repositories: repositories } })
+);
+
+if (process.env.NODE_ENV === "development") {
+  app.use("/graphiql", cors(), graphiqlExpress({ endpointURL: "/graphql" }));
 }
 
-app.listen(EXPRESS_PORT, () => {
-  console.log(  // eslint-disable-line no-console
-    colors.green('eq-author-api'),
-    'is running at',
-    colors.yellow(EXPRESS_URL + GRAPHIQL_ENDPOINT)
-  );
+app.listen(PORT, "0.0.0.0", () => {
+  console.log(colors.green("Listening on port"), PORT); // eslint-disable-line
 });

--- a/config/settings.js
+++ b/config/settings.js
@@ -1,17 +1,14 @@
-require('dotenv').config();
+require("dotenv").config();
 
 const {
   PORT = 4000,
-  SCHEME = "http://",
-  HOST = "localhost",
   GRAPHIQL_ENABLED,
   GRAPHIQL_ENDPOINT = "/graphiql",
   GRAPHIQL_PRETTY
 } = process.env;
 
 module.exports = {
-  EXPRESS_PORT: PORT,
-  EXPRESS_URL: SCHEME + HOST + ':' + PORT,
+  PORT,
   GRAPHIQL_ENABLED,
   GRAPHIQL_ENDPOINT,
   GRAPHIQL_PRETTY

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "jest-environment-node-debug": "^2.0.0",
     "knex": "^0.13.0",
     "lodash": "^4.17.4",
+    "morgan": "^1.9.0",
     "nodemon": "^1.11.0",
     "pg": "^6.2.3",
     "pg-hstore": "^2.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -403,6 +403,12 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+basic-auth@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.0.tgz#015db3f353e02e56377755f962742e8981e7bbba"
+  dependencies:
+    safe-buffer "5.1.1"
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
@@ -800,6 +806,12 @@ date-fns@^1.27.2:
 debug@2.6.8, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+  dependencies:
+    ms "2.0.0"
+
+debug@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
@@ -2874,6 +2886,16 @@ minimist@~1.1.0:
   dependencies:
     minimist "0.0.8"
 
+morgan@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.0.tgz#d01fa6c65859b76fcf31b3cb53a3821a311d8051"
+  dependencies:
+    basic-auth "~2.0.0"
+    debug "2.6.9"
+    depd "~1.1.1"
+    on-finished "~2.3.0"
+    on-headers "~1.0.1"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -3045,6 +3067,10 @@ on-finished@~2.3.0:
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   dependencies:
     ee-first "1.1.1"
+
+on-headers@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
 once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
@@ -3636,7 +3662,7 @@ rxjs@^5.0.0-beta.11:
   dependencies:
     symbol-observable "^1.0.1"
 
-safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 


### PR DESCRIPTION
### What is the context of this PR?
This PR adds some HTTP logging to the Author API using the `morgan` package. This is the same HTTP logging package used in Publisher.
This PR also does some tidying up refactoring of the API by removing some unnecessary environment variables.

### How to review 
HTTP logs should be displayed when making requests to the API.
