### PR TITLE
205 undo deletes

### DIFF
--- a/config/knexfile.js
+++ b/config/knexfile.js
@@ -1,39 +1,38 @@
 module.exports = {
-
   development: {
-    client: 'postgresql',
+    client: "postgresql",
     connection: process.env.DB_CONNECTION_URI
   },
 
   test: {
-    client: 'sqlite3',
+    client: "sqlite3",
     connection: {
-      filename: ':memory:'
-    }
+      filename: ":memory:"
+    },
+    useNullAsDefault: true
   },
 
   staging: {
-    client: 'postgresql',
+    client: "postgresql",
     connection: process.env.DB_CONNECTION_URI,
     pool: {
       min: 2,
       max: 10
     },
     migrations: {
-      tableName: 'knex_migrations'
+      tableName: "knex_migrations"
     }
   },
 
   production: {
-    client: 'postgresql',
+    client: "postgresql",
     connection: process.env.DB_CONNECTION_URI,
     pool: {
       min: 2,
       max: 10
     },
     migrations: {
-      tableName: 'knex_migrations'
+      tableName: "knex_migrations"
     }
   }
-
 };

--- a/db/Answer.js
+++ b/db/Answer.js
@@ -4,12 +4,9 @@ function Answer() {
   return db("Answers");
 }
 
-module.exports.findAll = function findAll(where = {}) {
-  return Answer()
-    .where(where)
-    .select();
+module.exports.findAll = function findAll() {
+  return Answer().select();
 };
-
 
 module.exports.findById = function findById(id) {
   return Answer()
@@ -35,4 +32,4 @@ module.exports.destroy = function destroy(id) {
     .where("id", parseInt(id, 10))
     .delete()
     .returning("*");
-}
+};

--- a/db/Option.js
+++ b/db/Option.js
@@ -4,22 +4,32 @@ function Option() {
   return db("Options");
 }
 
-module.exports.findAll = function findAll(where = {}) {
-  return Option().where(where).select();
+module.exports.findAll = function findAll() {
+  return Option().select();
 };
 
 module.exports.findById = function findById(id) {
-  return Option().where("id", parseInt(id, 10)).first();
+  return Option()
+    .where("id", parseInt(id, 10))
+    .first();
 };
 
 module.exports.update = function update(id, updates) {
-  return Option().where("id", parseInt(id, 10)).update(updates).returning("*");
+  return Option()
+    .where("id", parseInt(id, 10))
+    .update(updates)
+    .returning("*");
 };
 
 module.exports.create = function create(answer) {
-  return Option().insert(answer).returning("*");
+  return Option()
+    .insert(answer)
+    .returning("*");
 };
 
 module.exports.destroy = function destroy(id) {
-  return Option().where("id", parseInt(id, 10)).delete().returning("*");
+  return Option()
+    .where("id", parseInt(id, 10))
+    .delete()
+    .returning("*");
 };

--- a/db/Page.js
+++ b/db/Page.js
@@ -4,10 +4,8 @@ function Page() {
   return db("Pages");
 }
 
-module.exports.findAll = function findAll(where = {}) {
-  return Page()
-    .where(where)
-    .select();
+module.exports.findAll = function findAll() {
+  return Page().select();
 };
 
 module.exports.findById = function findById(id) {
@@ -18,7 +16,7 @@ module.exports.findById = function findById(id) {
 
 module.exports.update = function update(id, updates) {
   return Page()
-    .where({ "id" : parseInt(id, 10) })
+    .where({ id: parseInt(id, 10) })
     .update(updates)
     .returning("*");
 };
@@ -31,7 +29,7 @@ module.exports.create = function create(obj) {
 
 module.exports.destroy = function destroy(id) {
   return Page()
-    .where({ "id" : parseInt(id, 10) })
+    .where({ id: parseInt(id, 10) })
     .delete()
     .returning("*");
-}
+};

--- a/db/QuestionPage.js
+++ b/db/QuestionPage.js
@@ -4,16 +4,15 @@ function Question() {
   return db("Pages");
 }
 
-function restrictType(where) {
-  return Object.assign({}, where, { pageType : "QuestionPage" });
+function restrictType(where = {}) {
+  return Object.assign({}, where, { pageType: "QuestionPage" });
 }
 
-module.exports.findAll = function findAll(where = {}) {
+module.exports.findAll = function findAll() {
   return Question()
-    .where(restrictType(where))
+    .where(restrictType())
     .select();
 };
-
 
 module.exports.findById = function findById(id) {
   return Question()
@@ -39,4 +38,4 @@ module.exports.destroy = function destroy(id) {
     .where(restrictType({ id: parseInt(id, 10) }))
     .delete()
     .returning("*");
-}
+};

--- a/db/Questionnaire.js
+++ b/db/Questionnaire.js
@@ -4,12 +4,9 @@ function Questionnaire() {
   return db("Questionnaires");
 }
 
-module.exports.findAll = function findAll(where = {}) {
-  return Questionnaire()
-    .where(where)
-    .select();
+module.exports.findAll = function findAll() {
+  return Questionnaire().select();
 };
-
 
 module.exports.findById = function findById(id) {
   return Questionnaire()
@@ -35,4 +32,4 @@ module.exports.destroy = function destroy(id) {
     .where("id", parseInt(id, 10))
     .delete()
     .returning("*");
-}
+};

--- a/db/Section.js
+++ b/db/Section.js
@@ -4,12 +4,14 @@ function Section() {
   return db("Sections");
 }
 
-module.exports.findAll = function findAll(where = {}) {
-  return Section().where(where).select();
+module.exports.findAll = function findAll() {
+  return Section().select();
 };
 
 module.exports.findById = function findById(id) {
-  return Section().where("id", parseInt(id, 10)).first();
+  return Section()
+    .where("id", parseInt(id, 10))
+    .first();
 };
 
 module.exports.update = function update(id, updates) {
@@ -20,9 +22,14 @@ module.exports.update = function update(id, updates) {
 };
 
 module.exports.create = function create(obj) {
-  return Section().insert(obj).returning("*");
+  return Section()
+    .insert(obj)
+    .returning("*");
 };
 
 module.exports.destroy = function destroy(id) {
-  return Section().where({ id: parseInt(id, 10) }).delete().returning("*");
+  return Section()
+    .where({ id: parseInt(id, 10) })
+    .delete()
+    .returning("*");
 };

--- a/migrations/20171024153850_add_soft_delete.js
+++ b/migrations/20171024153850_add_soft_delete.js
@@ -1,0 +1,29 @@
+const IS_DELETED_COLUMN_NAME = "isDeleted";
+
+const TABLES_TO_CHANGE = [
+  "Questionnaires",
+  "Sections",
+  "Pages",
+  "Answers",
+  "Options"
+];
+
+const addIsDeletedColumn = table =>
+  table
+    .boolean(IS_DELETED_COLUMN_NAME)
+    .notNull()
+    .defaultTo(false);
+
+const dropIsDeletedColumn = table => table.dropColumn(IS_DELETED_COLUMN_NAME);
+
+exports.up = function(knex) {
+  return Promise.all(
+    TABLES_TO_CHANGE.map(t => knex.schema.table(t, addIsDeletedColumn))
+  );
+};
+
+exports.down = function(knex) {
+  return Promise.all(
+    TABLES_TO_CHANGE.map(t => knex.schema.table(t, dropIsDeletedColumn))
+  );
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "yarn knex -- migrate:latest && nodemon",
     "start:dev": "yarn knex -- migrate:latest && nodemon --inspect=0.0.0.0:5858",
     "lint": "eslint .",
-    "test": "jest .",
+    "test": "NODE_ENV=test jest .",
     "knex": "knex --knexfile config/knexfile.js --cwd .",
     "precommit": "lint-staged"
   },
@@ -23,7 +23,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^4.0.0",
-    "eq-author-graphql-schema": "ONSdigital/eq-author-graphql-schema#a3c5b69",
+    "eq-author-graphql-schema": "^0.3.0",
     "express": "^4.15.3",
     "express-pino-logger": "^2.0.0",
     "graphql": "^0.9.6",
@@ -60,6 +60,7 @@
     "eslint-config-eq-author": "^1.0.2",
     "husky": "^0.14.3",
     "lint-staged": "^4.0.2",
-    "prettier": "^1.5.3"
+    "prettier": "^1.5.3",
+    "sqlite3": "^3.1.13"
   }
 }

--- a/repositories/AnswerRepository.js
+++ b/repositories/AnswerRepository.js
@@ -1,21 +1,26 @@
 const { head, invert, map } = require("lodash/fp");
 const Answer = require("../db/Answer");
 const mapFields = require("../utils/mapFields");
-
 const mapping = { QuestionPageId: "questionPageId" };
 const fromDb = mapFields(mapping);
 const toDb = mapFields(invert(mapping));
 
 module.exports.findAll = function findAll(
-  where,
+  where = {},
   orderBy = "created_at",
   direction = "asc"
 ) {
-  return Answer.findAll(where).orderBy(orderBy, direction).then(map(fromDb));
+  return Answer.findAll()
+    .where({ isDeleted: false })
+    .where(where)
+    .orderBy(orderBy, direction)
+    .then(map(fromDb));
 };
 
 module.exports.get = function get(id) {
-  return Answer.findById(id).then(fromDb);
+  return Answer.findById(id)
+    .where({ isDeleted: false })
+    .then(fromDb);
 };
 
 module.exports.insert = function insert({
@@ -49,7 +54,8 @@ module.exports.update = function update({
   label,
   qCode,
   type,
-  mandatory
+  mandatory,
+  isDeleted
 }) {
   return Answer.update(id, {
     description,
@@ -57,12 +63,19 @@ module.exports.update = function update({
     label,
     qCode,
     type,
-    mandatory
+    mandatory,
+    isDeleted
   })
     .then(head)
     .then(fromDb);
 };
 
 module.exports.remove = function remove(id) {
-  return Answer.destroy(id).then(head).then(fromDb);
+  return Answer.update(id, { isDeleted: true })
+    .then(head)
+    .then(fromDb);
+};
+
+module.exports.undelete = function(id) {
+  return Answer.update(id, { isDeleted: false }).then(head);
 };

--- a/repositories/OptionRepository.js
+++ b/repositories/OptionRepository.js
@@ -1,21 +1,26 @@
 const { head, invert, map } = require("lodash/fp");
 const Option = require("../db/Option");
 const mapFields = require("../utils/mapFields");
-
 const mapping = { AnswerId: "answerId" };
 const fromDb = mapFields(mapping);
 const toDb = mapFields(invert(mapping));
 
 module.exports.findAll = function findAll(
-  where,
+  where = {},
   orderBy = "created_at",
   direction = "asc"
 ) {
-  return Option.findAll(where).orderBy(orderBy, direction).then(map(fromDb));
+  return Option.findAll()
+    .where({ isDeleted: false })
+    .where(where)
+    .orderBy(orderBy, direction)
+    .then(map(fromDb));
 };
 
 module.exports.get = function get(id) {
-  return Option.findById(id).then(fromDb);
+  return Option.findById(id)
+    .where({ isDeleted: false })
+    .then(fromDb);
 };
 
 module.exports.insert = function insert({
@@ -46,19 +51,27 @@ module.exports.update = function update({
   description,
   value,
   qCode,
-  childAnswerId
+  childAnswerId,
+  isDeleted
 }) {
   return Option.update(id, {
     label,
     description,
     value,
     qCode,
-    childAnswerId
+    childAnswerId,
+    isDeleted
   })
     .then(head)
     .then(fromDb);
 };
 
 module.exports.remove = function remove(id) {
-  return Option.destroy(id).then(head).then(fromDb);
+  return Option.update(id, { isDeleted: true })
+    .then(head)
+    .then(fromDb);
+};
+
+module.exports.undelete = function(id) {
+  return Option.update(id, { isDeleted: false }).then(head);
 };

--- a/repositories/PageRepository.js
+++ b/repositories/PageRepository.js
@@ -2,7 +2,6 @@ const { map, head } = require("lodash/fp");
 const Page = require("../db/Page");
 const QuestionPageRepository = require("./QuestionPageRepository");
 const mapFields = require("../utils/mapFields");
-
 const fromDb = mapFields({ SectionId: "sectionId" });
 
 function getRepositoryForType({ pageType }) {
@@ -15,15 +14,21 @@ function getRepositoryForType({ pageType }) {
 }
 
 module.exports.findAll = function findAll(
-  where,
+  where = {},
   orderBy = "created_at",
   direction = "asc"
 ) {
-  return Page.findAll(where).orderBy(orderBy, direction).then(map(fromDb));
+  return Page.findAll()
+    .where({ isDeleted: false })
+    .where(where)
+    .orderBy(orderBy, direction)
+    .then(map(fromDb));
 };
 
 module.exports.get = function get(id) {
-  return Page.findById(id).then(fromDb);
+  return Page.findById(id)
+    .where({ isDeleted: false })
+    .then(fromDb);
 };
 
 module.exports.insert = function insert(args) {
@@ -39,5 +44,11 @@ module.exports.update = function update(args) {
 };
 
 module.exports.remove = function remove(id) {
-  return Page.destroy(id).then(head).then(fromDb);
+  return Page.update(id, { isDeleted: true })
+    .then(head)
+    .then(fromDb);
+};
+
+module.exports.undelete = function(id) {
+  return Page.update(id, { isDeleted: false }).then(head);
 };

--- a/repositories/QuestionPageRepository.js
+++ b/repositories/QuestionPageRepository.js
@@ -1,23 +1,26 @@
 const { head, invert, map } = require("lodash/fp");
 const QuestionPage = require("../db/QuestionPage");
 const mapFields = require("../utils/mapFields");
-
 const mapping = { SectionId: "sectionId" };
 const fromDb = mapFields(mapping);
 const toDb = mapFields(invert(mapping));
 
 module.exports.findAll = function findAll(
-  where,
+  where = {},
   orderBy = "created_at",
   direction = "asc"
 ) {
-  return QuestionPage.findAll(where)
+  return QuestionPage.findAll()
+    .where({ isDeleted: false })
+    .where(where)
     .orderBy(orderBy, direction)
     .then(map(fromDb));
 };
 
 module.exports.get = function get(id) {
-  return QuestionPage.findById(id).then(fromDb);
+  return QuestionPage.findById(id)
+    .where({ isDeleted: false })
+    .then(fromDb);
 };
 
 module.exports.insert = function insert({
@@ -38,18 +41,29 @@ module.exports.insert = function insert({
     .then(fromDb);
 };
 
-module.exports.update = function update({ id, title, description, guidance }) {
+module.exports.update = function update({
+  id,
+  title,
+  description,
+  guidance,
+  isDeleted
+}) {
   return QuestionPage.update(id, {
     title,
     description,
-    guidance
+    guidance,
+    isDeleted
   })
     .then(head)
     .then(fromDb);
 };
 
 module.exports.remove = function remove(id) {
-  return QuestionPage.destroy(id)
+  return QuestionPage.update(id, { isDeleted: true })
     .then(head)
     .then(fromDb);
+};
+
+module.exports.undelete = function(id) {
+  return QuestionPage.update(id, { isDeleted: false }).then(head);
 };

--- a/repositories/QuestionnaireRepository.js
+++ b/repositories/QuestionnaireRepository.js
@@ -5,15 +5,19 @@ const mapping = { created_at: "createdAt" }; // eslint-disable-line camelcase
 const fromDb = mapFields(mapping);
 
 module.exports.get = function(id) {
-  return Questionnaire.findById(id).then(fromDb);
+  return Questionnaire.findById(id)
+    .where({ isDeleted: false })
+    .then(fromDb);
 };
 
 module.exports.findAll = function findAll(
-  where,
+  where = {},
   orderBy = "created_at",
   direction = "asc"
 ) {
-  return Questionnaire.findAll(where)
+  return Questionnaire.findAll()
+    .where({ isDeleted: false })
+    .where(where)
     .orderBy(orderBy, direction)
     .then(map(fromDb));
 };
@@ -36,10 +40,6 @@ module.exports.insert = function({
   }).then(head);
 };
 
-module.exports.remove = function(id) {
-  return Questionnaire.destroy(id).then(head);
-};
-
 module.exports.update = function({
   id,
   title,
@@ -47,7 +47,8 @@ module.exports.update = function({
   theme,
   legalBasis,
   navigation,
-  surveyId
+  surveyId,
+  isDeleted
 }) {
   return Questionnaire.update(id, {
     title,
@@ -55,6 +56,15 @@ module.exports.update = function({
     description,
     theme,
     legalBasis,
-    navigation
+    navigation,
+    isDeleted
   }).then(head);
+};
+
+module.exports.remove = function(id) {
+  return Questionnaire.update(id, { isDeleted: true }).then(head);
+};
+
+module.exports.undelete = function(id) {
+  return Questionnaire.update(id, { isDeleted: false }).then(head);
 };

--- a/repositories/QuestionnaireRepository.test.js
+++ b/repositories/QuestionnaireRepository.test.js
@@ -1,0 +1,135 @@
+const knex = require("../db/index");
+
+const createQuestionnaireTable = require("../migrations/20170620163533_create_questionnaires_table");
+const QuestionnaireRepository = require("../repositories/QuestionnaireRepository");
+
+const buildQuestionnaire = (json = {}) => {
+  return Object.assign(
+    {
+      title: "Test questionnaire",
+      surveyId: "1",
+      theme: "default",
+      legalBasis: "Voluntary",
+      navigation: 0
+    },
+    json
+  );
+};
+
+describe("QuestionnaireRepository", () => {
+  let questionnaire;
+
+  beforeEach(async () => {
+    await createQuestionnaireTable.up(knex);
+    await knex.schema.table("Questionnaires", t =>
+      t
+        .boolean("isDeleted")
+        .notNull()
+        .defaultTo(false)
+    );
+    questionnaire = buildQuestionnaire();
+  });
+
+  it("should create new Questionnaire", () => {
+    return QuestionnaireRepository.insert(questionnaire).then(result =>
+      expect(result).toEqual(1)
+    );
+  });
+
+  it("should retrieve a single questionnaire", () => {
+    return QuestionnaireRepository.insert(questionnaire).then(() => {
+      expect(QuestionnaireRepository.get(1)).resolves.toMatchObject(
+        questionnaire
+      );
+    });
+  });
+
+  it("should retrieve all questionnaires", () => {
+    return QuestionnaireRepository.insert(questionnaire)
+      .then(() =>
+        QuestionnaireRepository.insert(buildQuestionnaire({ surveyId: 2 }))
+      )
+      .then(() => QuestionnaireRepository.findAll())
+      .then(result => {
+        expect(result).toMatchObject([
+          {
+            id: 1,
+            isDeleted: 0
+          },
+          {
+            id: 2,
+            isDeleted: 0
+          }
+        ]);
+      });
+  });
+
+  it("should remove questionnaire", () => {
+    return QuestionnaireRepository.insert(questionnaire)
+      .then(() => QuestionnaireRepository.findAll())
+      .then(result => {
+        return expect(result).toMatchObject([
+          {
+            id: 1,
+            isDeleted: 0
+          }
+        ]);
+      })
+      .then(() => QuestionnaireRepository.remove(1))
+      .then(() => QuestionnaireRepository.findAll())
+      .then(result => {
+        return expect(result).toMatchObject([]);
+      });
+  });
+
+  it("should remove the correct questionnaire", () => {
+    return QuestionnaireRepository.insert(questionnaire)
+      .then(() =>
+        QuestionnaireRepository.insert(buildQuestionnaire({ surveyId: 2 }))
+      )
+      .then(() => QuestionnaireRepository.findAll())
+      .then(result => {
+        return expect(result).toMatchObject([
+          {
+            id: 1,
+            isDeleted: 0
+          },
+          {
+            id: 2,
+            isDeleted: 0
+          }
+        ]);
+      })
+      .then(() => QuestionnaireRepository.remove(2))
+      .then(() => QuestionnaireRepository.findAll())
+      .then(result => {
+        return expect(result).toMatchObject([
+          {
+            id: 1,
+            isDeleted: 0
+          }
+        ]);
+      });
+  });
+
+  it("should update questionnaires", () => {
+    return QuestionnaireRepository.insert(questionnaire)
+      .then(() =>
+        QuestionnaireRepository.update({ id: 1, surveyId: "updated" })
+      )
+      .then(() => QuestionnaireRepository.get(1))
+      .then(result => {
+        expect(result).toMatchObject({
+          surveyId: "updated"
+        });
+      });
+  });
+
+  afterEach(async () => {
+    await createQuestionnaireTable.down(knex);
+  });
+
+  afterAll(() => {
+    knex.destroy();
+  });
+});

--- a/repositories/SectionRepository.js
+++ b/repositories/SectionRepository.js
@@ -1,21 +1,26 @@
 const { head, invert, map } = require("lodash/fp");
 const Section = require("../db/Section");
 const mapFields = require("../utils/mapFields");
-
 const mapping = { QuestionnaireId: "questionnaireId" };
 const fromDb = mapFields(mapping);
 const toDb = mapFields(invert(mapping));
 
 module.exports.findAll = function findAll(
-  where,
+  where = {},
   orderBy = "created_at",
   direction = "asc"
 ) {
-  return Section.findAll(where).orderBy(orderBy, direction).then(map(fromDb));
+  return Section.findAll()
+    .where({ isDeleted: false })
+    .where(where)
+    .orderBy(orderBy, direction)
+    .then(map(fromDb));
 };
 
 module.exports.get = function get(id) {
-  return Section.findById(id).then(fromDb);
+  return Section.findById(id)
+    .where({ isDeleted: false })
+    .then(fromDb);
 };
 
 module.exports.insert = function insert({
@@ -34,15 +39,22 @@ module.exports.insert = function insert({
     .then(fromDb);
 };
 
-module.exports.update = function update({ id, title, description }) {
+module.exports.update = function update({ id, title, description, isDeleted }) {
   return Section.update(id, {
     title,
-    description
+    description,
+    isDeleted
   })
     .then(head)
     .then(fromDb);
 };
 
 module.exports.remove = function remove(id) {
-  return Section.destroy(id).then(head).then(fromDb);
+  return Section.update(id, { isDeleted: true })
+    .then(head)
+    .then(fromDb);
+};
+
+module.exports.undelete = function(id) {
+  return Section.update(id, { isDeleted: false }).then(head);
 };

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -35,6 +35,8 @@ const Resolvers = {
       ctx.repositories.Questionnaire.update(args.input),
     deleteQuestionnaire: (_, args, ctx) =>
       ctx.repositories.Questionnaire.remove(args.input.id),
+    undeleteQuestionnaire: (_, args, ctx) =>
+      ctx.repositories.Questionnaire.undelete(args.input.id),
 
     createSection: async (root, args, ctx) => {
       const section = await ctx.repositories.Section.insert(args.input);
@@ -52,10 +54,14 @@ const Resolvers = {
       ctx.repositories.Section.update(args.input),
     deleteSection: (_, args, ctx) =>
       ctx.repositories.Section.remove(args.input.id),
+    undeleteSection: (_, args, ctx) =>
+      ctx.repositories.Section.undelete(args.input.id),
 
     createPage: (root, args, ctx) => ctx.repositories.Page.insert(args.input),
     updatePage: (_, args, ctx) => ctx.repositories.Page.update(args.input),
     deletePage: (_, args, ctx) => ctx.repositories.Page.remove(args.input.id),
+    undeletePage: (_, args, ctx) =>
+      ctx.repositories.Page.undelete(args.input.id),
 
     createQuestionPage: (root, args, ctx) =>
       ctx.repositories.QuestionPage.insert(args.input),
@@ -63,6 +69,8 @@ const Resolvers = {
       ctx.repositories.QuestionPage.update(args.input),
     deleteQuestionPage: (_, args, ctx) =>
       ctx.repositories.QuestionPage.remove(args.input.id),
+    undeleteQuestionPage: (_, args, ctx) =>
+      ctx.repositories.QuestionPage.undelete(args.input.id),
 
     createAnswer: async (root, args, ctx) => {
       const answer = await ctx.repositories.Answer.insert(args.input);
@@ -95,12 +103,16 @@ const Resolvers = {
     updateAnswer: (_, args, ctx) => ctx.repositories.Answer.update(args.input),
     deleteAnswer: (_, args, ctx) =>
       ctx.repositories.Answer.remove(args.input.id),
+    undeleteAnswer: (_, args, ctx) =>
+      ctx.repositories.Answer.undelete(args.input.id),
 
     createOption: (root, args, ctx) =>
       ctx.repositories.Option.insert(args.input),
     updateOption: (_, args, ctx) => ctx.repositories.Option.update(args.input),
     deleteOption: (_, args, ctx) =>
-      ctx.repositories.Option.remove(args.input.id)
+      ctx.repositories.Option.remove(args.input.id),
+    undeleteOption: (_, args, ctx) =>
+      ctx.repositories.Option.undelete(args.input.id)
   },
 
   Questionnaire: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -961,9 +961,9 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-eq-author-graphql-schema@ONSdigital/eq-author-graphql-schema#a3c5b69:
-  version "0.1.1"
-  resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/a3c5b6982d2ec4c57f1ea6311bae7f8e35f12c8e"
+eq-author-graphql-schema@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.3.0.tgz#6821c3785275c29a7e358abde42305c5dda26930"
 
 errno@^0.1.4:
   version "0.1.4"
@@ -1796,7 +1796,7 @@ has@^1.0.1, has@~1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
-hawk@~3.1.3:
+hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
   dependencies:
@@ -2916,7 +2916,7 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
-nan@^2.3.0:
+nan@^2.3.0, nan@~2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
@@ -2960,6 +2960,21 @@ node-pre-gyp@^0.6.36:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tape "^4.6.3"
+    tar "^2.2.1"
+    tar-pack "^3.4.0"
+
+node-pre-gyp@~0.6.38:
+  version "0.6.38"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.38.tgz#e92a20f83416415bb4086f6d1fb78b3da73d113d"
+  dependencies:
+    hawk "3.1.3"
+    mkdirp "^0.5.1"
+    nopt "^4.0.1"
+    npmlog "^4.0.2"
+    rc "^1.1.7"
+    request "2.81.0"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
@@ -3593,7 +3608,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.79.0, request@^2.81.0:
+request@2.81.0, request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -3869,6 +3884,13 @@ split@^1.0.0:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+sqlite3@^3.1.13:
+  version "3.1.13"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-3.1.13.tgz#d990a05627392768de6278bafd1a31fdfe907dd9"
+  dependencies:
+    nan "~2.7.0"
+    node-pre-gyp "~0.6.38"
 
 sshpk@^1.7.0:
   version "1.13.1"


### PR DESCRIPTION
### What is the context of this PR?
This PR makes changes to the API, namely in the repositories and DB access layer to support soft deleting of Questionnaires, Sections, Pages, Answers and Options.
A new DB migration script has been included which adds a new column `state`. For now possible values for `state` are `Active` (the default value), and `Deleted`.
In future, there may be additional states such as 'Archived' or 'Locked' but that is not in scope for now.
A new integration test has been introduced to test soft deletion at the Questionnaire level.

### How to review 
When running the author against this branch, deleting a Questionnaire, Section, Question, Answer or Option should mark the correct record as being "Deleted".
The deleted element should no longer appear when using the application. The deleted element can be restored by setting the state value back to `Active`.