### PR TITLE
Add answers query to support piping feature.

### DIFF
--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -4,6 +4,12 @@ const { includes } = require("lodash");
 const getId = args => args.newId || args.id;
 const getNewId = entity => entity.id.toString(10);
 
+const whereIn = (field, values) => {
+  return function() {
+    this.where("id", "in", values);
+  };
+};
+
 const Resolvers = {
   Query: {
     questionnaires: (_, args, ctx) => ctx.repositories.Questionnaire.findAll(),
@@ -14,6 +20,8 @@ const Resolvers = {
     questionPage: (_, args, ctx) =>
       ctx.repositories.QuestionPage.get(getId(args)),
     answer: (root, args, ctx) => ctx.repositories.Answer.get(getId(args)),
+    answers: (root, { ids }, ctx) =>
+      ctx.repositories.Answer.findAll(whereIn("id", ids)),
     option: (root, args, ctx) => ctx.repositories.Option.get(getId(args))
   },
 

--- a/tests/schema/queries/answers.test.js
+++ b/tests/schema/queries/answers.test.js
@@ -1,0 +1,40 @@
+const executeQuery = require("../../utils/executeQuery");
+const mockRepository = require("../../utils/mockRepository");
+
+describe("answers query", () => {
+  const answer = `
+    query GetAnswers($ids: [ID]!) {
+      answers(ids: $ids) {
+        label
+        id
+      }
+    }
+  `;
+
+  let repositories;
+  const ids = ["1", "2", "3"];
+  const answers = ids.map(id => ({ id, label: `Label${1}` }));
+
+  beforeEach(() => {
+    repositories = {
+      Answer: mockRepository({
+        findAll: answers
+      })
+    };
+  });
+
+  it("should fetch answers by id", async () => {
+    const result = await executeQuery(answer, { ids }, { repositories });
+    const { findAll } = repositories.Answer;
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data.answers).toEqual(answers);
+    expect(findAll).toHaveBeenCalledWith(expect.any(Function));
+
+    // ensure correct knex methods are called
+    const fn = findAll.mock.calls[0][0];
+    const where = jest.fn();
+    fn.call({ where });
+    expect(where).toHaveBeenCalledWith("id", "in", ids);
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?
* Switch to using [npm published schema](https://www.npmjs.com/package/eq-author-graphql-schema)
* To support piping, implements `answers` query defined in schema.
* Add tests

### How to review 
Review code, run tests, test new query in graphiql
