### PR TITLE
Add summary property to Questionnaire in the API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ In most cases sensible defaults have been selected.
 | Environment Variable | Description |
 | -------------------- | ----------- |
 | PORT                 | The port which express listens on (defaults to `4000`). |
-| HOST                 | The hostname where API resides (defaults to `localhost`). |
-| SCHEME               | `http://` or `https://` (defaults to `http://`) |
 | GRAPHIQL_ENABLED     | Enable the Graphiql interface (`true` or `false`) |
 | GRAPHIQL_ENDPOINT    | The endpoint which graphiql listens on (defaults to `/graphiql`) |
 | GRAPHIQL_PRETTY      | Pretty print Graphiql output (`true` or `false`) |

--- a/migrations/20171116131851_add_summary_column.js
+++ b/migrations/20171116131851_add_summary_column.js
@@ -3,10 +3,7 @@ const SUMMARY_COLUMN = "summary";
 
 exports.up = function(knex) {
   return knex.schema.table(QUESTIONNAIRES_TABLE, table => {
-    table
-      .boolean(SUMMARY_COLUMN)
-      .notNullable()
-      .defaultsTo(false);
+    table.bool(SUMMARY_COLUMN).defaultsTo(false);
   });
 };
 

--- a/migrations/20171116131851_add_summary_column.js
+++ b/migrations/20171116131851_add_summary_column.js
@@ -1,0 +1,17 @@
+const QUESTIONNAIRES_TABLE = "Questionnaires";
+const SUMMARY_COLUMN = "summary";
+
+exports.up = function(knex) {
+  return knex.schema.table(QUESTIONNAIRES_TABLE, table => {
+    table
+      .boolean(SUMMARY_COLUMN)
+      .notNullable()
+      .defaultsTo(false);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(QUESTIONNAIRES_TABLE, table => {
+    table.dropColumn(SUMMARY_COLUMN);
+  });
+};

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^4.0.0",
-    "eq-author-graphql-schema": "^0.3.0",
+    "eq-author-graphql-schema": "^0.4.0",
     "express": "^4.15.3",
     "express-pino-logger": "^2.0.0",
     "graphql": "^0.9.6",

--- a/repositories/QuestionnaireRepository.js
+++ b/repositories/QuestionnaireRepository.js
@@ -28,7 +28,8 @@ module.exports.insert = function({
   theme,
   legalBasis,
   navigation,
-  surveyId
+  surveyId,
+  summary
 }) {
   return Questionnaire.create({
     title,
@@ -36,7 +37,8 @@ module.exports.insert = function({
     theme,
     legalBasis,
     navigation,
-    surveyId
+    surveyId,
+    summary
   }).then(head);
 };
 
@@ -48,7 +50,8 @@ module.exports.update = function({
   legalBasis,
   navigation,
   surveyId,
-  isDeleted
+  isDeleted,
+  summary
 }) {
   return Questionnaire.update(id, {
     title,
@@ -57,7 +60,8 @@ module.exports.update = function({
     theme,
     legalBasis,
     navigation,
-    isDeleted
+    isDeleted,
+    summary
   }).then(head);
 };
 

--- a/repositories/QuestionnaireRepository.test.js
+++ b/repositories/QuestionnaireRepository.test.js
@@ -1,6 +1,7 @@
 const knex = require("../db/index");
 
 const createQuestionnaireTable = require("../migrations/20170620163533_create_questionnaires_table");
+const addSummaryColumn = require("../migrations/20171116131851_add_summary_column");
 const QuestionnaireRepository = require("../repositories/QuestionnaireRepository");
 
 const buildQuestionnaire = (json = {}) => {
@@ -21,6 +22,7 @@ describe("QuestionnaireRepository", () => {
 
   beforeEach(async () => {
     await createQuestionnaireTable.up(knex);
+    await addSummaryColumn.up(knex);
     await knex.schema.table("Questionnaires", t =>
       t
         .boolean("isDeleted")
@@ -126,6 +128,7 @@ describe("QuestionnaireRepository", () => {
   });
 
   afterEach(async () => {
+    await addSummaryColumn.down(knex);
     await createQuestionnaireTable.down(knex);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -961,9 +961,9 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-eq-author-graphql-schema@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.3.0.tgz#6821c3785275c29a7e358abde42305c5dda26930"
+eq-author-graphql-schema@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.4.0.tgz#db8cafa4720579059f24c210fae75613f7dfc436"
 
 errno@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
### What is the context of this PR?
This PR makes changes to the API in order to support the new `summary` property on Questionnaires.

### How to review 
All tests and checks should pass.
It should be possible to persist and retrieve the `summary` property for a Questionnaire after applying this PR.
