### PR TITLE
Upgrade API to run using Node 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "7"
+  - "8"
 
 before_install:
   - yarn add codecov

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7
+FROM node:8
 EXPOSE 4000
 ENV PORT=4000
 WORKDIR /app


### PR DESCRIPTION
### What is the context of this PR?
This PR updates the travis configuration so that API builds and tests run in a Node 8 (LTS) environment.
The docker configuration has also been updated so that the API runs using Node 8

### How to review 
All tests and checks should pass.
Visual inspection of travis build log to ensure Node 8 is being used.
Pull down docker image for this branch and inspect it to make sure it is using Node 8 and that it runs as expected.
