### PR TITLE
consistently map fields from db

### DIFF
--- a/repositories/AnswerRepository.js
+++ b/repositories/AnswerRepository.js
@@ -88,7 +88,9 @@ module.exports.remove = function remove(id) {
 };
 
 module.exports.undelete = function(id) {
-  return Answer.update(id, { isDeleted: false }).then(head);
+  return Answer.update(id, { isDeleted: false })
+    .then(head)
+    .then(fromDb);
 };
 
 module.exports.getOtherAnswer = function(
@@ -101,13 +103,14 @@ module.exports.getOtherAnswer = function(
     .where({ isDeleted: false, parentAnswerId: id })
     .where(where)
     .orderBy(orderBy, direction)
-    .first();
+    .first()
+    .then(fromDb);
 };
 
 module.exports.createOtherAnswer = ({ id }) => {
-  return db.transaction(trx => createOtherAnswer(trx, { id }));
+  return db.transaction(trx => createOtherAnswer(trx, { id }).then(fromDb));
 };
 
 module.exports.deleteOtherAnswer = ({ id }) => {
-  return db.transaction(trx => deleteOtherAnswer(trx, { id }));
+  return db.transaction(trx => deleteOtherAnswer(trx, { id }).then(fromDb));
 };

--- a/repositories/OptionRepository.js
+++ b/repositories/OptionRepository.js
@@ -69,5 +69,7 @@ module.exports.remove = function remove(id) {
 };
 
 module.exports.undelete = function(id) {
-  return Option.update(id, { isDeleted: false }).then(head);
+  return Option.update(id, { isDeleted: false })
+    .then(head)
+    .then(fromDb);
 };

--- a/repositories/PageRepository.js
+++ b/repositories/PageRepository.js
@@ -82,7 +82,9 @@ module.exports.remove = function remove(id) {
 };
 
 module.exports.undelete = function(id) {
-  return Page.update(id, { isDeleted: false }).then(head);
+  return Page.update(id, { isDeleted: false })
+    .then(head)
+    .then(fromDb);
 };
 
 module.exports.move = ({ id, sectionId, position }) => {

--- a/repositories/QuestionPageRepository.js
+++ b/repositories/QuestionPageRepository.js
@@ -67,5 +67,7 @@ module.exports.remove = function remove(id) {
 };
 
 module.exports.undelete = function(id) {
-  return QuestionPage.update(id, { isDeleted: false }).then(head);
+  return QuestionPage.update(id, { isDeleted: false })
+    .then(head)
+    .then(fromDb);
 };

--- a/repositories/QuestionnaireRepository.js
+++ b/repositories/QuestionnaireRepository.js
@@ -41,7 +41,9 @@ module.exports.insert = function({
     surveyId,
     summary,
     createdBy
-  }).then(head);
+  })
+    .then(head)
+    .then(fromDb);
 };
 
 module.exports.update = function({
@@ -64,13 +66,19 @@ module.exports.update = function({
     navigation,
     isDeleted,
     summary
-  }).then(head);
+  })
+    .then(head)
+    .then(fromDb);
 };
 
 module.exports.remove = function(id) {
-  return Questionnaire.update(id, { isDeleted: true }).then(head);
+  return Questionnaire.update(id, { isDeleted: true })
+    .then(head)
+    .then(fromDb);
 };
 
 module.exports.undelete = function(id) {
-  return Questionnaire.update(id, { isDeleted: false }).then(head);
+  return Questionnaire.update(id, { isDeleted: false })
+    .then(head)
+    .then(fromDb);
 };

--- a/repositories/SectionRepository.js
+++ b/repositories/SectionRepository.js
@@ -56,5 +56,7 @@ module.exports.remove = function remove(id) {
 };
 
 module.exports.undelete = function(id) {
-  return Section.update(id, { isDeleted: false }).then(head);
+  return Section.update(id, { isDeleted: false })
+    .then(head)
+    .then(fromDb);
 };


### PR DESCRIPTION
### What is the context of this PR?
Use `fromDb` helper to map fields name from DB naming convention to Schema naming convention. This ensures that we can always select fields via graphql query

### How to review 
Tests pass, changes look good