### PR TITLE
Fixes null description passed through for `other` answer.

### DIFF
--- a/repositories/strategies/multipleChoiceOtherAnswerStrategy.js
+++ b/repositories/strategies/multipleChoiceOtherAnswerStrategy.js
@@ -9,6 +9,7 @@ const createAnswer = async (trx, parentAnswerId, type) =>
   trx("Answers")
     .insert({
       mandatory: false,
+      description: "",
       type,
       parentAnswerId
     })

--- a/schema/resolvers.test.js
+++ b/schema/resolvers.test.js
@@ -106,7 +106,7 @@ describe("resolvers", () => {
     expect(checkboxAnswer.other).toBeNull();
 
     const other = await createOther(checkboxAnswer);
-    expect(other.answer).toMatchObject({ type: "TextField" });
+    expect(other.answer).toMatchObject({ type: "TextField", description: "" });
 
     const updatedCheckboxAnswer = await refreshAnswerDetails(checkboxAnswer);
     expect(updatedCheckboxAnswer.other).not.toBeNull();

--- a/tests/utils/graphql.js
+++ b/tests/utils/graphql.js
@@ -53,6 +53,7 @@ const createOtherMutation = `
       answer {
         id
         type
+        description
       }
     }
   }
@@ -67,6 +68,7 @@ const deleteOtherMutation = `
       answer {
         id
         type
+        description
       }
     }
   }
@@ -90,6 +92,7 @@ const getAnswerQuery = `
           answer {
             id
             type
+            description
           }
           option {
             id


### PR DESCRIPTION
### What is the context of this PR?
There is an issue where null values are being returned for other answer description.

This change to the API should ensure that other answers have an empty string
description by default.

This is only an issue because the other answer is a hidden field. So users cannot
provide a value.

### How to review 
 - Code changes look good.
 - All tests pass.
