### PR TITLE
Improvements to move page feature

### DIFF
--- a/db/Page.js
+++ b/db/Page.js
@@ -1,6 +1,6 @@
-const db = require("./");
+const knex = require("./");
 
-function Page() {
+function Page(db = knex) {
   return db("Pages");
 }
 
@@ -14,8 +14,8 @@ module.exports.findById = function findById(id) {
     .first();
 };
 
-module.exports.update = function update(id, updates) {
-  return Page()
+module.exports.update = function update(id, updates, db) {
+  return Page(db)
     .where({ id: parseInt(id, 10) })
     .update(updates)
     .returning("*");

--- a/migrations/20180501142343_add_view_table_for_pages.js
+++ b/migrations/20180501142343_add_view_table_for_pages.js
@@ -1,0 +1,16 @@
+exports.up = function(knex) {
+  return knex.raw(`
+    CREATE OR REPLACE VIEW "PagesView" AS (
+      SELECT *, ROW_NUMBER () OVER (
+        PARTITION BY "SectionId"
+        ORDER BY "order" ASC
+      ) - 1 AS "position"
+      FROM "Pages"
+      WHERE "isDeleted" = false
+    )
+  `);
+};
+
+exports.down = function(knex) {
+  return knex.raw(`DROP VIEW "PagesView"`);
+};

--- a/repositories/PageRepository.js
+++ b/repositories/PageRepository.js
@@ -1,13 +1,11 @@
-const { map, head, invert } = require("lodash/fp");
+const { map, head, invert, get } = require("lodash/fp");
 const Page = require("../db/Page");
 const QuestionPageRepository = require("./QuestionPageRepository");
 const mapFields = require("../utils/mapFields");
 const db = require("../db");
 const {
   movePage,
-  getNextOrderValue,
-  calculatedPositionCol,
-  getPosition
+  getNextOrderValue
 } = require("./strategies/spacedOrderStrategy");
 
 const mapping = { SectionId: "sectionId" };
@@ -23,26 +21,22 @@ function getRepositoryForType({ pageType }) {
   }
 }
 
-module.exports.findAll = function findAll(
-  where = {},
-  orderBy = "position",
-  direction = "asc"
-) {
-  return Page.findAll()
-    .columns("*", calculatedPositionCol(db))
-    .where({ isDeleted: false })
+function findAll(where = {}, orderBy = "position", direction = "asc") {
+  return db("PagesView")
+    .select("*")
     .where(toDb(where))
     .orderBy(orderBy, direction)
     .then(map(fromDb));
-};
+}
 
-module.exports.get = function get(id) {
-  return Page.findById(id)
-    .where({ isDeleted: false })
+function getById(id) {
+  return db("PagesView")
+    .where("id", parseInt(id, 10))
+    .first()
     .then(fromDb);
-};
+}
 
-module.exports.insert = function insert(args) {
+function insert(args) {
   const repository = getRepositoryForType(args);
 
   return db.transaction(trx => {
@@ -68,33 +62,42 @@ module.exports.insert = function insert(args) {
       )
       .then(fromDb);
   });
-};
+}
 
-module.exports.update = function update(args) {
+function update(args) {
   const repository = getRepositoryForType(args);
   return repository.update(args);
-};
+}
 
-module.exports.remove = function remove(id) {
+function remove(id) {
   return Page.update(id, { isDeleted: true })
     .then(head)
     .then(fromDb);
-};
+}
 
-module.exports.undelete = function(id) {
+function undelete(id) {
   return Page.update(id, { isDeleted: false })
     .then(head)
     .then(fromDb);
-};
+}
 
-module.exports.move = ({ id, sectionId, position }) => {
+function move({ id, sectionId, position }) {
   return db.transaction(trx =>
     movePage(trx, { id, sectionId, position }).then(fromDb)
   );
-};
+}
 
-module.exports.getPosition = ({ id }) => {
-  return Page.findById(id).then(({ SectionId }) =>
-    getPosition(db, SectionId, id)
-  );
-};
+function getPosition({ id }) {
+  return getById(id).then(get("position"));
+}
+
+Object.assign(module.exports, {
+  findAll,
+  get: getById,
+  insert,
+  update,
+  remove,
+  undelete,
+  move,
+  getPosition
+});

--- a/repositories/PageRepository.test.js
+++ b/repositories/PageRepository.test.js
@@ -6,8 +6,6 @@ const { last, head, map, times } = require("lodash");
 
 const reverse = array => array.slice().reverse();
 
-jest.setTimeout(1000 * 60 * 10); // 10 minute
-
 const buildQuestionnaire = questionnaire => ({
   title: "Test questionnaire",
   surveyId: "1",
@@ -397,7 +395,7 @@ describe("PagesRepository", () => {
       expect(map(updatedResults, "id")).toEqual(map(reverse(pages), "id"));
     });
 
-    it("handles moving single page to it's own position", async () => {
+    it("handles moving single page to its own position", async () => {
       const { section } = await setup();
       const pages = await createPages(section.id, 3);
 

--- a/repositories/PageRepository.test.js
+++ b/repositories/PageRepository.test.js
@@ -6,6 +6,8 @@ const { last, head, map, times } = require("lodash");
 
 const reverse = array => array.slice().reverse();
 
+jest.setTimeout(1000 * 60 * 10); // 10 minute
+
 const buildQuestionnaire = questionnaire => ({
   title: "Test questionnaire",
   surveyId: "1",
@@ -110,7 +112,7 @@ describe("PagesRepository", () => {
     await PageRepository.undelete(page.id);
 
     const result = await PageRepository.get(page.id);
-    expect(result).toEqual(page);
+    expect(result).toMatchObject(page);
   });
 
   describe("re-ordering", () => {

--- a/repositories/strategies/spacedOrderStrategy.js
+++ b/repositories/strategies/spacedOrderStrategy.js
@@ -1,78 +1,58 @@
-const { map } = require("lodash/fp");
+const {
+  isEmpty,
+  flow,
+  last,
+  clamp,
+  getOr,
+  isNil,
+  reject
+} = require("lodash/fp");
 
 const SPACING = 1000;
 
-const calculateMidPoint = (orderBefore, orderAfter) =>
-  Math.round((orderBefore + orderAfter) / 2);
+const calculateMidPoint = (a, b) => Math.round((a + b) / 2);
 
 const valuesHaveConverged = (orderBefore, orderAfter) =>
   Math.abs(orderAfter - orderBefore) < 2;
 
-const getNextOrderValue = (trx, SectionId) => {
-  return trx("PagesView")
-    .column(trx.raw(`COALESCE(max("order"), 0) + ${SPACING} as "order"`))
-    .where({ SectionId });
-};
-
-const setOrder = (trx, id, SectionId, order) => {
-  return trx("Pages")
-    .where({ id })
-    .update({ order, SectionId })
-    .returning("*");
-};
-
-const getAdjacentRows = (trx, id, SectionId, position) => {
-  return trx("PagesView")
-    .columns("id", "order")
-    .where({ SectionId })
-    .where("id", "!=", id)
-    .orderBy("order")
-    .offset(Math.max(0, position - 1))
-    .limit(2)
-    .then(map("order"));
-};
-
-const makeSpaceAfter = (trx, order, SectionId) => {
-  return trx("Pages")
+const makeSpaceForInsert = (trx, SectionId, order) =>
+  trx("Pages")
     .where({ SectionId })
     .andWhere("order", ">", order)
     .increment("order", SPACING);
-};
 
-const movePage = async (trx, { id, sectionId, position }) => {
-  position = Math.max(0, position);
+const getPagesBySection = (trx, SectionId) =>
+  trx("PagesView")
+    .columns("id", "order")
+    .where({ SectionId })
+    .orderBy("order");
 
-  let rows = await getAdjacentRows(trx, id, sectionId, position);
+const getMaxOrder = flow(last, getOr(0, "order"));
 
-  // there are two cases in which there are no adjacent rows
-  // 1. inserting into empty list
-  // 2. inserting at position beyond end of list (e.g. inserting at position 10, where only 10 items in list)
-  if (rows.length === 0) {
-    const [{ order }] = await getNextOrderValue(trx, sectionId);
-    rows = [order, order + SPACING];
+const getOrUpdateOrderForInsert = async (trx, sectionId, id, position) => {
+  const pages = reject({ id }, await getPagesBySection(trx, sectionId));
+  const maxOrder = getMaxOrder(pages) + SPACING;
+
+  position = isNil(position) ? pages.length : clamp(0, pages.length, position);
+
+  if (isEmpty(pages)) {
+    return SPACING;
+  }
+  if (position === pages.length) {
+    return maxOrder;
   }
 
-  if (position === 0) {
-    // inserting at start of list, there is no actual left-hand value
-    rows = [0, rows[0]];
-  } else if (rows.length === 1) {
-    // inserting at end of list, there is no actual right-hand value
-    rows = [rows[0], rows[0] + SPACING];
+  let left = getOr(0, "order", pages[position - 1]);
+  let right = getOr(maxOrder, "order", pages[position]);
+
+  if (valuesHaveConverged(left, right)) {
+    await makeSpaceForInsert(trx, sectionId, left);
+    right += SPACING;
   }
 
-  if (valuesHaveConverged(...rows)) {
-    await makeSpaceAfter(trx, rows[0], sectionId);
-    // now that space has been made for insertion, bring local data up to date
-    rows[1] += SPACING;
-  }
-
-  const [page] = await setOrder(trx, id, sectionId, calculateMidPoint(...rows));
-
-  // assign position to the page object, so that data can be resolved locally by graphql
-  return Object.assign(page, { position });
+  return calculateMidPoint(left, right);
 };
 
 module.exports = {
-  getNextOrderValue,
-  movePage
+  getOrUpdateOrderForInsert
 };


### PR DESCRIPTION
### What is the context of this PR?
* Simplifies some awkward logic around computing the `position` value for pages. Possibly needs some indexes or something added. Need to investigate further. But for now the code works
* Simplifies logic around calculating `order` values when moving pages
* Reduces number of round trips to DB, at cost of bigger payload from DB
* Improves performance of inserts - previously would insert at end of list, _then_ perform a move operation to place at correct position. Now inserts directly at correct position

### How to review 
Run tests. Run e2e tests. Check code is sensible