### PR TITLE
Implement routing on api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:8-alpine
 EXPOSE 4000
 ENV PORT=4000
 WORKDIR /app
@@ -11,4 +11,3 @@ ENTRYPOINT ["yarn", "start"]
 
 COPY . /app
 RUN yarn install
-RUN yarn upgrade eq-author-graphql-schema

--- a/db/Routing.js
+++ b/db/Routing.js
@@ -1,0 +1,79 @@
+const db = require("./");
+const { parseInt } = require("lodash");
+const RoutingRuleSets = "Routing_RuleSets";
+const RoutingRules = "Routing_Rules";
+const RoutingConditions = "Routing_Conditions";
+const RoutingConditionValues = "Routing_ConditionValues";
+const RoutingDestinations = "Routing_Destinations";
+
+const table = (tableName, knex = db) => knex(tableName);
+const select = (tableName, knex = db) => table(tableName, knex).select();
+const selectById = (tableName, id, knex = db) =>
+  select(tableName, knex)
+    .where("id", parseInt(id))
+    .first();
+const insert = (tableName, record, knex = db) =>
+  table(tableName, knex)
+    .insert(record)
+    .returning("*");
+const update = (tableName, id, record, knex = db) =>
+  table(tableName, knex)
+    .where("id", parseInt(id))
+    .update(record)
+    .returning("*");
+const deleteById = (tableName, id, knex = db) =>
+  table(tableName, knex)
+    .where({ id })
+    .del()
+    .returning("*");
+
+const findAllRoutingRuleSets = () => select(RoutingRuleSets);
+const findAllRoutingRules = () => select(RoutingRules);
+const findAllRoutingConditions = () => select(RoutingConditions);
+const findAllRoutingConditionValues = () => select(RoutingConditionValues);
+
+const findRoutingRuleSetsById = id => selectById(RoutingRuleSets, id);
+const findRoutingRulesById = id => selectById(RoutingRules, id);
+const findRoutingConditionValuesById = id =>
+  selectById(RoutingConditionValues, id);
+const findRoutingDestinationById = id => selectById(RoutingDestinations, id);
+
+const createRoutingRuleSet = values => insert(RoutingRuleSets, values);
+const createRoutingRule = values => insert(RoutingRules, values);
+const createRoutingCondition = values => insert(RoutingConditions, values);
+const createRoutingConditionValue = values =>
+  insert(RoutingConditionValues, values);
+
+const updateRoutingRuleSet = (id, values) =>
+  update(RoutingRuleSets, id, values);
+const updateRoutingRule = (id, values) => update(RoutingRules, id, values);
+const updateRoutingCondition = (id, values) =>
+  update(RoutingConditions, id, values);
+const updateRoutingConditionValue = (id, values) =>
+  update(RoutingConditionValues, id, values);
+
+const updateRoutingDestination = (id, values) =>
+  update(RoutingDestinations, id, values);
+
+const deleteRoutingCondition = id => deleteById(RoutingConditions, id);
+
+Object.assign(module.exports, {
+  findAllRoutingRuleSets,
+  findAllRoutingRules,
+  findAllRoutingConditions,
+  findAllRoutingConditionValues,
+  findRoutingRuleSetsById,
+  findRoutingRulesById,
+  findRoutingConditionValuesById,
+  createRoutingRuleSet,
+  createRoutingRule,
+  createRoutingCondition,
+  createRoutingConditionValue,
+  updateRoutingRuleSet,
+  updateRoutingRule,
+  updateRoutingCondition,
+  updateRoutingConditionValue,
+  deleteRoutingCondition,
+  findRoutingDestinationById,
+  updateRoutingDestination
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - db
     volumes:
       - .:/app
-      - ./node_modules/eq-author-graphql-schema:/app/node_modules/eq-author-graphql-schema
+      # - ./node_modules/eq-author-graphql-schema:/app/node_modules/eq-author-graphql-schema
     ports:
       - 4000:4000
       - 5858:5858 # open port for debugging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - db
     volumes:
       - .:/app
-      # - ./node_modules/eq-author-graphql-schema:/app/node_modules/eq-author-graphql-schema
+      - ./node_modules/eq-author-graphql-schema:/app/node_modules/eq-author-graphql-schema
     ports:
       - 4000:4000
       - 5858:5858 # open port for debugging

--- a/migrations/20180430155015_creating_routing_databases.js
+++ b/migrations/20180430155015_creating_routing_databases.js
@@ -1,0 +1,140 @@
+const createRoutingRuleSetTable = async knex => {
+  return knex.schema.createTable("Routing_RuleSets", function(table) {
+    table.increments();
+
+    table
+      .integer("QuestionPageId")
+      .unsigned()
+      .references("id")
+      .inTable("Pages")
+      .onDelete("CASCADE");
+
+    table
+      .integer("RoutingDestinationId")
+      .unsigned()
+      .references("id")
+      .inTable("Routing_Destinations")
+      .onDelete("CASCADE");
+
+    table
+      .boolean("isDeleted")
+      .notNull()
+      .defaultTo(false);
+  });
+};
+
+const createRoutingRuleTable = async knex => {
+  return knex.schema.createTable("Routing_Rules", function(table) {
+    table.increments();
+
+    table.enum("operation", ["And", "Or"]).notNullable();
+
+    table
+      .integer("RoutingRuleSetId")
+      .unsigned()
+      .references("id")
+      .inTable("Routing_RuleSets")
+      .onDelete("CASCADE");
+
+    table
+      .integer("RoutingDestinationId")
+      .unsigned()
+      .references("id")
+      .inTable("Routing_Destinations")
+      .onDelete("CASCADE");
+
+    table
+      .boolean("isDeleted")
+      .notNull()
+      .defaultTo(false);
+  });
+};
+
+const createRoutingConditionTable = async knex => {
+  return knex.schema.createTable("Routing_Conditions", function(table) {
+    table.increments();
+
+    table.enum("comparator", ["Equal", "NotEqual"]).notNullable();
+
+    table
+      .integer("RoutingRuleId")
+      .unsigned()
+      .references("id")
+      .inTable("Routing_Rules")
+      .onDelete("CASCADE");
+
+    table
+      .integer("QuestionPageId")
+      .unsigned()
+      .references("id")
+      .inTable("Pages")
+      .onDelete("CASCADE");
+
+    table
+      .integer("AnswerId")
+      .unsigned()
+      .references("id")
+      .inTable("Answers")
+      .onDelete("CASCADE");
+  });
+};
+
+const createRoutingConditionValuesTable = async knex => {
+  return knex.schema.createTable("Routing_ConditionValues", function(table) {
+    table.increments();
+
+    table
+      .integer("OptionId")
+      .unsigned()
+      .references("id")
+      .inTable("Options")
+      .onDelete("CASCADE");
+
+    table
+      .integer("ConditionId")
+      .unsigned()
+      .references("id")
+      .inTable("Routing_Conditions")
+      .onDelete("CASCADE");
+  });
+};
+
+const createRoutingDestinationsTable = async knex => {
+  return knex.schema.createTable("Routing_Destinations", table => {
+    table.increments();
+
+    table
+      .enum("logicalDestination", ["NextPage", "EndOfQuestionnaire"])
+      .defaultTo("NextPage");
+
+    table
+      .integer("PageId")
+      .unsigned()
+      .references("id")
+      .inTable("Pages")
+      .onDelete("CASCADE");
+
+    table
+      .integer("SectionId")
+      .unsigned()
+      .references("id")
+      .inTable("Sections")
+      .onDelete("CASCADE");
+  });
+};
+
+exports.up = async function(knex) {
+  await createRoutingDestinationsTable(knex);
+  await createRoutingRuleSetTable(knex);
+  await createRoutingRuleTable(knex);
+  await createRoutingConditionTable(knex);
+  await createRoutingConditionValuesTable(knex);
+};
+
+exports.down = async function(knex) {
+  await knex.schema.dropTable("Routing_ConditionValues");
+  await knex.schema.dropTable("Routing_Conditions");
+  await knex.schema.dropTable("Routing_Rules");
+  await knex.schema.dropTable("Routing_RuleSets");
+  await knex.schema.dropTable("Routing_Destinations");
+};

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^6.0.0",
-    "eq-author-graphql-schema": "^0.14.2",
+    "eq-author-graphql-schema": "^0.15.0",
     "express": "^4.15.3",
     "express-pino-logger": "^3.0.1",
     "graphql": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
   },
   "dependencies": {
     "body-parser": "^1.17.2",
+    "cheerio": "^1.0.0-rc.2",
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^6.0.0",
-    "eq-author-graphql-schema": "^0.13.0",
+    "eq-author-graphql-schema": "^0.14.2",
     "express": "^4.15.3",
     "express-pino-logger": "^3.0.1",
     "graphql": "^0.13.2",

--- a/repositories/RoutingRepository.js
+++ b/repositories/RoutingRepository.js
@@ -1,0 +1,274 @@
+const { head, invert, map } = require("lodash/fp");
+const { get, isNil, parseInt } = require("lodash");
+const db = require("../db");
+const mapFields = require("../utils/mapFields");
+
+const {
+  updateRoutingConditionStrategy,
+  updateRoutingConditionValueStrategy,
+  getAvailableRoutingDestinations,
+  checkRoutingDestinations,
+  createRoutingRuleSetStrategy,
+  createRoutingRuleStrategy,
+  createRoutingConditionStrategy,
+  resolveRoutingDestinationStrategy
+} = require("./strategies/routingStrategy");
+
+const Routing = require("../db/Routing");
+const PageRepository = require("./PageRepository");
+const SectionRepository = require("./SectionRepository");
+
+const mapping = {
+  QuestionPageId: "questionPageId",
+  RoutingRuleSetId: "routingRuleSetId",
+  RoutingRuleId: "routingRuleId",
+  AnswerId: "answerId",
+  OptionId: "optionId",
+  ConditionId: "conditionId",
+  PageId: "pageId",
+  SectionId: "sectionId",
+  RoutingDestinationId: "routingDestinationId"
+};
+const fromDb = mapFields(mapping);
+const toDb = mapFields(invert(mapping));
+
+const getRoutingDestinations = async pageId => {
+  const logicalDestinations = [
+    {
+      logicalDestination: "NextPage"
+    },
+    {
+      logicalDestination: "EndOfQuestionnaire"
+    }
+  ];
+  const absoluteDestinations = await db.transaction(trx =>
+    getAvailableRoutingDestinations(trx, pageId)
+  );
+  return {
+    logicalDestinations,
+    ...absoluteDestinations
+  };
+};
+
+const checkValidDestination = async (questionPageId, destination) => {
+  if (isNil(destination)) {
+    throw new Error(`Invalid destination specified for routing rule`);
+  }
+
+  const { logicalDestination, absoluteDestination } = destination;
+  if (!isNil(logicalDestination) && !isNil(absoluteDestination)) {
+    throw new Error("Routing destination cannot be both logical and absolute");
+  }
+
+  const availableRoutingDestinations = await getRoutingDestinations(
+    questionPageId
+  );
+  await checkRoutingDestinations(availableRoutingDestinations, destination);
+};
+
+function findRoutingRuleSetByQuestionPageId(where = {}) {
+  return Routing.findAllRoutingRuleSets()
+    .where({ isDeleted: false })
+    .where(where)
+    .first()
+    .then(fromDb);
+}
+
+function findAllRoutingRules(where = {}) {
+  return Routing.findAllRoutingRules()
+    .where({ isDeleted: false })
+    .where(where)
+    .then(map(fromDb));
+}
+
+function getRoutingRuleById(id) {
+  return Routing.findAllRoutingRules()
+    .where({ id, isDeleted: false })
+    .first()
+    .then(fromDb);
+}
+
+function getRoutingRuleSetById(id) {
+  return Routing.findAllRoutingRuleSets()
+    .where(toDb({ id: parseInt(id), isDeleted: false }))
+    .then(head)
+    .then(fromDb);
+}
+
+function findAllRoutingConditions(where = {}) {
+  return Routing.findAllRoutingConditions()
+    .where(where)
+    .then(map(fromDb));
+}
+
+function getRoutingConditionValue(where = {}) {
+  return Routing.findAllRoutingConditionValues()
+    .where(toDb(where))
+    .first()
+    .then(fromDb)
+    .then(res => get(res, "optionId"));
+}
+
+function createRoutingRuleSet({ questionPageId }) {
+  return db.transaction(trx =>
+    createRoutingRuleSetStrategy(trx, questionPageId).then(fromDb)
+  );
+}
+
+const deleteRoutingRuleSet = ({ id }) =>
+  Routing.updateRoutingRuleSet(
+    id,
+    toDb({
+      isDeleted: true
+    })
+  )
+    .then(head)
+    .then(fromDb);
+
+async function createRoutingRule(createRoutingRuleInput) {
+  return db.transaction(trx =>
+    createRoutingRuleStrategy(trx, createRoutingRuleInput)
+  );
+}
+
+function createRoutingCondition(routingCondition) {
+  return db.transaction(trx =>
+    createRoutingConditionStrategy(trx, routingCondition)
+  );
+}
+
+const updateRoutingConditionValue = async ({ conditionId, optionId }) =>
+  db.transaction(trx =>
+    updateRoutingConditionValueStrategy(trx, {
+      conditionId,
+      optionId
+    })
+  );
+
+const updateDestination = async (id, destination) => {
+  const { logicalDestination, absoluteDestination } = destination;
+
+  const updatedFields = {
+    logicalDestination: get(logicalDestination, "destinationType", null),
+    pageId: null,
+    sectionId: null
+  };
+
+  if (!isNil(absoluteDestination)) {
+    const key =
+      absoluteDestination.destinationType === "QuestionPage"
+        ? "pageId"
+        : "sectionId";
+
+    updatedFields[key] = parseInt(absoluteDestination.destinationId);
+  }
+
+  return Routing.updateRoutingDestination(id, toDb(updatedFields))
+    .then(head)
+    .then(fromDb);
+};
+
+async function updateRoutingRuleSet({ id, else: destination }) {
+  const routingRuleSet = await getRoutingRuleSetById(id);
+
+  const { questionPageId, routingDestinationId } = routingRuleSet;
+  await checkValidDestination(questionPageId, destination);
+
+  await updateDestination(routingDestinationId, destination);
+
+  return routingRuleSet;
+}
+
+async function updateRoutingRule({ id, goto: destination }) {
+  const routingRule = await getRoutingRuleById(id);
+  const routingRuleSet = await getRoutingRuleSetById(
+    routingRule.routingRuleSetId
+  );
+
+  const { routingDestinationId } = routingRule;
+
+  await checkValidDestination(routingRuleSet.questionPageId, destination);
+  await updateDestination(routingDestinationId, destination);
+
+  // No need to update rule since there is not mechanism to change the operation yet
+  return routingRule;
+}
+
+function updateRoutingCondition({ id, questionPageId, answerId }) {
+  return db.transaction(trx =>
+    updateRoutingConditionStrategy(trx, { id, questionPageId, answerId }).then(
+      fromDb
+    )
+  );
+}
+
+function removeRoutingRule({ id }) {
+  return Routing.updateRoutingRule(id, { isDeleted: true })
+    .then(head)
+    .then(fromDb);
+}
+
+function removeRoutingCondition({ id }) {
+  return Routing.deleteRoutingCondition(id).then(() => null);
+}
+
+function undeleteRoutingRule(id) {
+  return Routing.updateRoutingRule(id, { isDeleted: false })
+    .then(head)
+    .then(fromDb);
+}
+
+function resolveRoutingDestination(sectionId, pageId) {
+  if (isNil(sectionId)) {
+    return null;
+  }
+
+  return db.transaction(trx =>
+    resolveRoutingDestinationStrategy(trx, sectionId, pageId)
+  );
+}
+
+const getRoutingDestination = async routingDestinationId => {
+  const destination = await Routing.findRoutingDestinationById(
+    routingDestinationId
+  ).then(fromDb);
+
+  if (!destination) {
+    return null;
+  }
+
+  if (destination.sectionId) {
+    const section = await SectionRepository.get(destination.sectionId);
+    return section ? { absoluteDestination: section } : null;
+  }
+
+  if (destination.pageId) {
+    const page = await PageRepository.get(destination.pageId);
+    return page ? { absoluteDestination: page } : null;
+  }
+
+  if (destination.logicalDestination) {
+    return { logicalDestination: destination.logicalDestination };
+  }
+};
+
+Object.assign(module.exports, {
+  undeleteRoutingRule,
+  removeRoutingCondition,
+  removeRoutingRule,
+  updateRoutingCondition,
+  updateRoutingRule,
+  findRoutingRuleSetByQuestionPageId,
+  findAllRoutingRules,
+  findAllRoutingConditions,
+  getRoutingConditionValue,
+  createRoutingRuleSet,
+  createRoutingRule,
+  createRoutingCondition,
+  updateRoutingConditionValue,
+  updateRoutingRuleSet,
+  getRoutingDestinations,
+  resolveRoutingDestination,
+  deleteRoutingRuleSet,
+  getRoutingDestination
+});

--- a/repositories/index.js
+++ b/repositories/index.js
@@ -4,5 +4,6 @@ module.exports = {
   Page: require("./PageRepository"),
   QuestionPage: require("./QuestionPageRepository"),
   Answer: require("./AnswerRepository"),
-  Option: require("./OptionRepository")
+  Option: require("./OptionRepository"),
+  Routing: require("./RoutingRepository")
 };

--- a/repositories/strategies/routingStrategy.js
+++ b/repositories/strategies/routingStrategy.js
@@ -178,21 +178,12 @@ const updateRoutingConditionValueStrategy = async (
   { conditionId, optionId }
 ) => {
   const table = trx("Routing_ConditionValues");
-  const where = toDb({ conditionId: parseInt(conditionId) });
-
-  const parsedOptionId = parseInt(optionId);
-  const optionNotSet = isNaN(parsedOptionId);
-
-  const update = toDb({
-    conditionId: parseInt(conditionId),
-    optionId: optionNotSet ? null : parsedOptionId
-  });
-
+  const where = toDb({ conditionId });
   const existing = await table.where(where);
 
   const query = isEmpty(existing)
-    ? table.insert(update)
-    : table.where(where).update(update);
+    ? table.insert(toDb({ conditionId, optionId }))
+    : table.where(where).update(toDb({ optionId }));
 
   return query
     .returning("*")

--- a/repositories/strategies/routingStrategy.js
+++ b/repositories/strategies/routingStrategy.js
@@ -1,0 +1,368 @@
+const { head, invert, map } = require("lodash/fp");
+const { parseInt, isNil, find, isEmpty, get } = require("lodash");
+
+const mapFields = require("../../utils/mapFields");
+
+const mapping = {
+  QuestionnaireId: "questionnaireId",
+  SectionId: "sectionId",
+  QuestionPageId: "questionPageId",
+  ElseDestination: "elseDestination",
+  RoutingRuleSetId: "routingRuleSetId",
+  RuleDestination: "ruleDestination",
+  RoutingRuleId: "routingRuleId",
+  AnswerId: "answerId",
+  OptionId: "optionId",
+  ConditionId: "conditionId",
+  SectionDestinationId: "sectionDestinationId",
+  PageDestinationId: "pageDestinationId",
+  RoutingDestinationId: "routingDestinationId"
+};
+
+const toDb = mapFields(invert(mapping));
+const fromDb = mapFields(mapping);
+
+const updateAllRoutingConditions = (trx, where, values) =>
+  trx("Routing_Conditions")
+    .where(toDb(where))
+    .update(toDb(values))
+    .returning("*");
+
+const updateRoutingCondition = (trx, id, questionPageId, answerId) =>
+  trx("Routing_Conditions")
+    .where({ id })
+    .update(
+      toDb({
+        questionPageId,
+        answerId
+      })
+    )
+    .returning("*")
+    .then(head)
+    .then(fromDb);
+
+const getFirstAnswer = (trx, questionPageId) =>
+  trx("Answers")
+    .where(toDb({ questionPageId, isDeleted: false }))
+    .orderBy("id")
+    .first()
+    .then(fromDb);
+
+const findAnswerByIdAndQuestionPageId = (trx, id, questionPageId) =>
+  trx("Answers")
+    .where({ isDeleted: false })
+    .where(toDb({ id, questionPageId }))
+    .then(head)
+    .then(fromDb);
+
+const deleteRoutingConditionValues = (trx, where) =>
+  trx("Routing_ConditionValues")
+    .where(toDb(where))
+    .del();
+
+const getPageById = (trx, id) =>
+  trx("PagesView")
+    .where({ id })
+    .first()
+    .then(fromDb);
+
+const getSectionById = (trx, id) =>
+  trx("Sections")
+    .where({ id, isDeleted: false })
+    .first()
+    .then(fromDb);
+
+const getPageDestinations = (trx, { sectionId, order }) =>
+  trx("PagesView")
+    .where(toDb({ sectionId }))
+    .where("order", ">", order)
+    .then(map(fromDb));
+
+const getSectionDestinations = (trx, { id, questionnaireId }) =>
+  trx("Sections")
+    .select("*")
+    .where(toDb({ questionnaireId, isDeleted: false }))
+    .where("id", ">", id)
+    .then(map(fromDb));
+
+const findRoutingRuleSet = (trx, questionPageId) =>
+  trx("Routing_RuleSets")
+    .where(toDb({ questionPageId, isDeleted: false }))
+    .first()
+    .then(fromDb);
+
+const getRoutingRuleSetById = (trx, routingRuleSetId) => {
+  return trx("Routing_RuleSets")
+    .where(toDb({ id: routingRuleSetId, isDeleted: false }))
+    .first()
+    .then(fromDb);
+};
+
+const insertRoutingCondition = (trx, routingCondition) =>
+  trx("Routing_Conditions")
+    .insert(toDb(routingCondition))
+    .returning("*")
+    .then(head)
+    .then(fromDb);
+
+const insertRoutingRule = (trx, routingRule) =>
+  trx("Routing_Rules")
+    .insert(toDb(routingRule))
+    .returning("*")
+    .then(head)
+    .then(fromDb);
+
+const insertRoutingRuleSet = async (
+  trx,
+  { questionPageId, routingDestinationId }
+) =>
+  trx("Routing_RuleSets")
+    .insert(
+      toDb({
+        questionPageId: parseInt(questionPageId),
+        routingDestinationId: parseInt(routingDestinationId)
+      })
+    )
+    .returning("*")
+    .then(head)
+    .then(fromDb);
+
+const checkAnswerBelongsToPage = async (trx, answerId, questionPageId) => {
+  if (isNil(answerId)) {
+    return;
+  }
+
+  const answer = await findAnswerByIdAndQuestionPageId(
+    trx,
+    answerId,
+    questionPageId
+  );
+  if (!answer) {
+    throw new Error(
+      `Answer ${answerId} does not belong to ${questionPageId}. Choose a different answer.`
+    );
+  }
+};
+
+const getAnswerOrFirstAnswerOnPage = async (trx, answerId, questionPageId) => {
+  if (!isNil(answerId)) {
+    return answerId;
+  }
+  const firstAnswer = await getFirstAnswer(trx, questionPageId);
+  return get(firstAnswer, "id", null);
+};
+
+const updateRoutingConditionStrategy = async (
+  trx,
+  { id: routingConditionId, questionPageId, answerId }
+) => {
+  await checkAnswerBelongsToPage(trx, answerId, questionPageId);
+  const routingConditionAnswer = await getAnswerOrFirstAnswerOnPage(
+    trx,
+    answerId,
+    questionPageId
+  );
+  await deleteRoutingConditionValues(trx, {
+    conditionId: routingConditionId
+  });
+  return updateRoutingCondition(
+    trx,
+    routingConditionId,
+    questionPageId,
+    routingConditionAnswer
+  );
+};
+
+const updateRoutingConditionValueStrategy = async (
+  trx,
+  { conditionId, optionId }
+) => {
+  const table = trx("Routing_ConditionValues");
+  const where = toDb({ conditionId: parseInt(conditionId) });
+
+  const parsedOptionId = parseInt(optionId);
+  const optionNotSet = isNaN(parsedOptionId);
+
+  const update = toDb({
+    conditionId: parseInt(conditionId),
+    optionId: optionNotSet ? null : parsedOptionId
+  });
+
+  const existing = await table.where(where);
+
+  const query = isEmpty(existing)
+    ? table.insert(update)
+    : table.where(where).update(update);
+
+  return query
+    .returning("*")
+    .then(head)
+    .then(fromDb);
+};
+
+async function getAvailableRoutingDestinations(trx, pageId) {
+  const page = await getPageById(trx, pageId);
+  const section = await getSectionById(trx, page.sectionId);
+  const questionPages = await getPageDestinations(trx, page);
+  const sections = await getSectionDestinations(trx, section);
+
+  return {
+    questionPages,
+    sections
+  };
+}
+
+const checkRoutingDestinations = async (
+  availableRoutingDestinations,
+  destination
+) => {
+  const { logicalDestinations } = availableRoutingDestinations;
+  const { logicalDestination, absoluteDestination } = destination;
+
+  if (!isNil(logicalDestination)) {
+    if (
+      !find(logicalDestinations, {
+        logicalDestination: logicalDestination.destinationType
+      })
+    ) {
+      throw new Error(
+        `Unable to route from this question ${logicalDestination.destinationType}`
+      );
+    }
+  }
+
+  if (!isNil(absoluteDestination)) {
+    const { destinationType, destinationId } = absoluteDestination;
+    const key =
+      destinationType === "QuestionPage" ? "questionPages" : "sections";
+    if (
+      !find(availableRoutingDestinations[key], { id: parseInt(destinationId) })
+    ) {
+      throw new Error(
+        `Unable to route from this question to ${destinationType} ${destinationId}`
+      );
+    }
+  }
+};
+
+async function createRoutingConditionStrategy(trx, routingCondition) {
+  const { questionPageId, answerId } = routingCondition;
+  let firstAnswerOnPage;
+  if (isNil(answerId)) {
+    firstAnswerOnPage = await getFirstAnswer(trx, questionPageId);
+  }
+
+  return insertRoutingCondition(trx, {
+    ...routingCondition,
+    answerId: get(firstAnswerOnPage, "id", answerId)
+  });
+}
+
+const createRoutingDestination = async trx =>
+  trx("Routing_Destinations")
+    .insert({})
+    .returning("*")
+    .then(head)
+    .then(fromDb);
+
+async function createRoutingRuleStrategy(
+  trx,
+  { routingRuleSetId, operation = "And" }
+) {
+  const routingDestination = await createRoutingDestination(trx);
+
+  const routingRule = await insertRoutingRule(trx, {
+    operation,
+    routingRuleSetId,
+    routingDestinationId: routingDestination.id
+  });
+
+  const routingRuleSet = await getRoutingRuleSetById(
+    trx,
+    routingRule.routingRuleSetId
+  );
+
+  await createRoutingConditionStrategy(trx, {
+    comparator: "Equal",
+    routingRuleId: routingRule.id,
+    questionPageId: routingRuleSet.questionPageId
+  });
+
+  return routingRule;
+}
+
+async function createRoutingRuleSetStrategy(trx, questionPageId) {
+  const existingRuleSet = await findRoutingRuleSet(trx, questionPageId);
+  if (!isNil(existingRuleSet)) {
+    throw new Error(
+      `Cannot add a second RoutingRuleSet to question ${questionPageId}. Delete the existing one first.`
+    );
+  }
+
+  const routingDestination = await createRoutingDestination(trx);
+  const routingRuleSetDefaults = {
+    questionPageId,
+    routingDestinationId: routingDestination.id
+  };
+
+  const routingRuleSet = await insertRoutingRuleSet(
+    trx,
+    routingRuleSetDefaults
+  );
+
+  const routingRuleInput = {
+    routingRuleSetId: routingRuleSet.id
+  };
+
+  await createRoutingRuleStrategy(trx, routingRuleInput);
+  return routingRuleSet;
+}
+
+async function resolveRoutingDestinationStrategy(trx, sectionId, pageId) {
+  return isNil(pageId)
+    ? getSectionById(trx, sectionId)
+    : getPageById(trx, pageId);
+}
+
+const handlePageDeleted = (trx, pageId) =>
+  updateAllRoutingConditions(
+    trx,
+    {
+      questionPageId: parseInt(pageId)
+    },
+    {
+      questionPageId: null,
+      answerId: null
+    }
+  );
+
+const handleAnswerDeleted = (trx, answerId) =>
+  updateAllRoutingConditions(
+    trx,
+    {
+      answerId: parseInt(answerId)
+    },
+    {
+      questionPageId: null,
+      answerId: null
+    }
+  );
+
+const handleOptionDeleted = (trx, optionId) =>
+  deleteRoutingConditionValues(trx, {
+    optionId: parseInt(optionId)
+  });
+
+Object.assign(module.exports, {
+  checkRoutingDestinations,
+  getAvailableRoutingDestinations,
+  updateRoutingConditionValueStrategy,
+  updateRoutingConditionStrategy,
+  createRoutingRuleSetStrategy,
+  createRoutingRuleStrategy,
+  createRoutingConditionStrategy,
+  resolveRoutingDestinationStrategy,
+  handlePageDeleted,
+  handleAnswerDeleted,
+  handleOptionDeleted
+});

--- a/repositories/strategies/routingStrategy.js
+++ b/repositories/strategies/routingStrategy.js
@@ -318,12 +318,6 @@ async function createRoutingRuleSetStrategy(trx, questionPageId) {
   return routingRuleSet;
 }
 
-async function resolveRoutingDestinationStrategy(trx, sectionId, pageId) {
-  return isNil(pageId)
-    ? getSectionById(trx, sectionId)
-    : getPageById(trx, pageId);
-}
-
 const handlePageDeleted = (trx, pageId) =>
   updateAllRoutingConditions(
     trx,
@@ -361,7 +355,6 @@ Object.assign(module.exports, {
   createRoutingRuleSetStrategy,
   createRoutingRuleStrategy,
   createRoutingConditionStrategy,
-  resolveRoutingDestinationStrategy,
   handlePageDeleted,
   handleAnswerDeleted,
   handleOptionDeleted

--- a/repositories/strategies/routingStrategy.test.js
+++ b/repositories/strategies/routingStrategy.test.js
@@ -1,0 +1,26 @@
+const { checkRoutingDestinations } = require("./routingStrategy");
+
+describe("repositories / strategies / routingStrategy", () => {
+  it("should error when trying to navigate to a logical destination that doesn't exist", () => {
+    const availableRoutingDestinations = {
+      logicalDestinations: [
+        {
+          logicalDestination: "NextPage"
+        },
+        {
+          logicalDestination: "Summary"
+        }
+      ]
+    };
+
+    const destination = {
+      logicalDestination: {
+        destinationType: "DoesNotExist"
+      }
+    };
+
+    expect(
+      checkRoutingDestinations(availableRoutingDestinations, destination)
+    ).rejects.toThrowError();
+  });
+});

--- a/schema/resolvers.test.js
+++ b/schema/resolvers.test.js
@@ -1025,6 +1025,42 @@ describe("resolvers", () => {
         });
       });
 
+      it("should error if trying to update a condition with an invalid question/answer combo", async () => {
+        // Given page A with answer I
+        // And page B with answer J
+        // When I update a routing condition with question A answer J
+        // Then I should get an error
+
+        const section = first(sections);
+        const pageA = firstPage;
+        const pageB = await addPage(section.id);
+
+        const answerI = await createNewAnswer(pageA, "Checkbox");
+        const answerJ = await createNewAnswer(pageB, "Checkbox");
+
+        const routingInfo = await getRoutingDataForPage(pageA);
+        const routingCondition = get(
+          routingInfo,
+          "routingRuleSet.routingRules[0].conditions[0]"
+        );
+
+        const res1 = await changeRoutingConditionMutation({
+          id: routingCondition.id,
+          questionPageId: pageA.id,
+          answerId: answerJ.id
+        });
+
+        expect(res1.errors).toHaveLength(1);
+
+        const res2 = await changeRoutingConditionMutation({
+          id: routingCondition.id,
+          questionPageId: pageB.id,
+          answerId: answerI.id
+        });
+
+        expect(res2.errors).toHaveLength(1);
+      });
+
       describe("routing condition values", () => {
         it("should only be possible to select one option per condition", async () => {
           // Given a checkbox with two options 1 and 2

--- a/schema/resolvers.test.js
+++ b/schema/resolvers.test.js
@@ -1,4 +1,4 @@
-const { first } = require("lodash");
+const { first, get } = require("lodash");
 const repositories = require("../repositories");
 const db = require("../db");
 const executeQuery = require("../tests/utils/executeQuery");
@@ -8,7 +8,27 @@ const {
   createOtherMutation,
   deleteOtherMutation,
   getAnswerQuery,
-  getAnswersQuery
+  getPageQuery,
+  getAnswersQuery,
+  createRoutingRuleSet,
+  updateRoutingRule,
+  updateRoutingConditionValue,
+  getEntireRoutingStructure,
+  getBasicRoutingQuery,
+  updateCondition,
+  createSectionMutation,
+  createQuestionPageMutation,
+  getAvailableRoutingDestinations,
+  updateRoutingRuleSet,
+  deleteRoutingRuleSet,
+  createRoutingRule,
+  deleteRoutingRule,
+  createRoutingCondition,
+  deleteRoutingCondition,
+  deletePageMutation,
+  deleteAnswerMutation,
+  deleteOptionMutation,
+  createOptionMutation
 } = require("../tests/utils/graphql");
 
 const ctx = { repositories };
@@ -33,6 +53,18 @@ const createNewQuestionnaire = async () => {
   return result.data.createQuestionnaire;
 };
 
+const createSection = async questionnaireId =>
+  executeQuery(
+    createSectionMutation,
+    {
+      input: {
+        title: "Foo",
+        questionnaireId: questionnaireId
+      }
+    },
+    ctx
+  );
+
 const createNewAnswer = async ({ id: pageId }, type) => {
   const input = {
     description: "",
@@ -47,6 +79,17 @@ const createNewAnswer = async ({ id: pageId }, type) => {
   const result = await executeQuery(createAnswerMutation, { input }, ctx);
   return result.data.createAnswer;
 };
+
+const createOption = async answerId =>
+  executeQuery(
+    createOptionMutation,
+    {
+      input: {
+        answerId
+      }
+    },
+    ctx
+  );
 
 const createNewOtherMutation = async answer =>
   executeQuery(
@@ -71,6 +114,35 @@ const deleteOther = async answer =>
     ctx
   );
 
+const deleteQuestionPage = async input =>
+  executeQuery(
+    deletePageMutation,
+    {
+      input
+    },
+    ctx
+  );
+
+const deleteAnswer = async ({ id }) =>
+  executeQuery(
+    deleteAnswerMutation,
+    {
+      input: {
+        id
+      }
+    },
+    ctx
+  );
+
+const deleteOption = async input =>
+  executeQuery(
+    deleteOptionMutation,
+    {
+      input
+    },
+    ctx
+  );
+
 const createThenDeleteOther = async (page, type) => {
   const answer = await createNewAnswer(page, type);
   await createOther(answer);
@@ -78,6 +150,157 @@ const createThenDeleteOther = async (page, type) => {
 
   return answer;
 };
+
+const createNewRoutingRuleSet = async questionPageId => {
+  return executeQuery(
+    createRoutingRuleSet,
+    {
+      input: {
+        questionPageId
+      }
+    },
+    ctx
+  );
+};
+
+const deleteRoutingRuleSetMutation = async id => {
+  return executeQuery(
+    deleteRoutingRuleSet,
+    {
+      input: {
+        id
+      }
+    },
+    ctx
+  );
+};
+
+const createNewRoutingRule = async input => {
+  return executeQuery(
+    createRoutingRule,
+    {
+      input
+    },
+    ctx
+  );
+};
+
+const createNewRoutingCondition = async input => {
+  return executeQuery(
+    createRoutingCondition,
+    {
+      input
+    },
+    ctx
+  );
+};
+
+const updateRoutingRuleSetMutation = async input =>
+  executeQuery(
+    updateRoutingRuleSet,
+    {
+      input
+    },
+    ctx
+  );
+
+const updateRoutingRuleMutation = (destinationType, destinationId, id) =>
+  executeQuery(
+    updateRoutingRule,
+    {
+      input: {
+        id,
+        operation: "And",
+        goto: {
+          absoluteDestination: {
+            destinationType,
+            destinationId
+          }
+        }
+      }
+    },
+    ctx
+  );
+
+const deleteRoutingRuleMutation = async input =>
+  executeQuery(
+    deleteRoutingRule,
+    {
+      input
+    },
+    ctx
+  );
+
+const deleteRoutingConditionMutation = async input =>
+  executeQuery(
+    deleteRoutingCondition,
+    {
+      input
+    },
+    ctx
+  );
+
+const updateRoutingConditionValueMutation = async (conditionId, optionId) =>
+  executeQuery(
+    updateRoutingConditionValue,
+    {
+      input: {
+        conditionId,
+        optionId
+      }
+    },
+    ctx
+  );
+
+const changeRoutingConditionMutation = async input =>
+  executeQuery(
+    updateCondition,
+    {
+      input
+    },
+    ctx
+  );
+
+const changeRoutingCondition = async (firstPage, answer, conditionId) => {
+  const RoutingCondition = await changeRoutingConditionMutation({
+    id: conditionId,
+    questionPageId: firstPage.id,
+    answerId: answer.id
+  });
+  return RoutingCondition.data;
+};
+
+const createFullRoutingTree = async firstPage => {
+  await createNewRoutingRuleSet(firstPage.id);
+  const result = await executeQuery(
+    getBasicRoutingQuery,
+    { id: firstPage.id },
+    ctx
+  );
+  const routingConditionId = get(
+    result,
+    "data.page.routingRuleSet.routingRules[0].conditions[0].id"
+  );
+
+  const answer = await createNewAnswer(firstPage, "Checkbox");
+
+  const routingConditionValue = await updateRoutingConditionValueMutation(
+    routingConditionId,
+    first(answer.options).id
+  ).then(res => res.data);
+
+  return { routingConditionId, answer, routingConditionValue };
+};
+
+const getFullRoutingTree = async firstPage =>
+  executeQuery(getEntireRoutingStructure, { id: firstPage.id }, ctx);
+
+const createQuestionPage = async id =>
+  executeQuery(
+    createQuestionPageMutation,
+    { input: { title: "Bar", sectionId: id } },
+    ctx
+  );
 
 const refreshAnswerDetails = async ({ id }) => {
   const result = await executeQuery(getAnswerQuery, { id }, ctx);
@@ -224,5 +447,640 @@ describe("resolvers", () => {
 
     expect(secondAttempt).toHaveProperty("errors");
     expect(secondAttempt.errors).toHaveLength(1);
+  });
+
+  it("should create a RoutingRule and RoutingCondition on RoutingRuleSet creation", async () => {
+    await createNewRoutingRuleSet(firstPage.id);
+    const result = await executeQuery(
+      getBasicRoutingQuery,
+      { id: firstPage.id },
+      ctx
+    );
+
+    expect(get(result, "data.page.routingRuleSet.routingRules")).toHaveLength(
+      1
+    );
+
+    expect(
+      get(result, "data.page.routingRuleSet.routingRules[0].conditions")
+    ).toHaveLength(1);
+  });
+
+  it("should delete routing rule set", async () => {
+    const routingRuleSet = await createNewRoutingRuleSet(firstPage.id).then(
+      res => res.data.createRoutingRuleSet
+    );
+
+    const result = await deleteRoutingRuleSetMutation(routingRuleSet.id);
+
+    expect(result).toMatchObject({
+      data: {
+        deleteRoutingRuleSet: {
+          id: routingRuleSet.id
+        }
+      }
+    });
+
+    expect(
+      executeQuery(getBasicRoutingQuery, { id: firstPage.id }, ctx)
+    ).resolves.toMatchObject({
+      data: {
+        page: {
+          id: firstPage.id,
+          routingRuleSet: null
+        }
+      }
+    });
+  });
+
+  it("should error if you make a second RoutingRuleSet on one question", async () => {
+    await createNewRoutingRuleSet(firstPage.id);
+    const secondAttempt = await createNewRoutingRuleSet(firstPage.id);
+
+    expect(secondAttempt.errors).toHaveLength(1);
+  });
+
+  it("should error if you try route the question to itself", async () => {
+    const routingRuleSet = await createNewRoutingRuleSet(firstPage.id);
+    const ruleId = get(
+      routingRuleSet,
+      "data.createRoutingRuleSet.routingRules[0].id"
+    );
+    const page = await executeQuery(getPageQuery, { id: firstPage.id }, ctx);
+    const result = await updateRoutingRuleMutation(
+      "QuestionPage",
+      page.id,
+      ruleId
+    );
+
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it("should error if you route it to the beginning of its own section", async () => {
+    const routingRuleSet = await createNewRoutingRuleSet(firstPage.id);
+    const page = await executeQuery(getPageQuery, { id: firstPage.id }, ctx);
+    const result = await updateRoutingRuleSetMutation(
+      get(routingRuleSet, "data.createRoutingRuleSet.id"),
+      {
+        else: {
+          absoluteDestination: {
+            destinationType: "Section",
+            destinationId: get(page, "data.questionPage.section.id")
+          }
+        }
+      }
+    );
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it("can create a Routing Condition and can toggle a optionValue on", async () => {
+    const routingTree = await createFullRoutingTree(firstPage);
+    let routingStructure = await getFullRoutingTree(firstPage);
+
+    let routingConditions = get(
+      routingStructure,
+      "data.questionPage.routingRuleSet.routingRules[0].conditions"
+    );
+
+    expect(routingConditions).toHaveLength(1);
+    expect(get(first(routingConditions), "routingValue.value")).toEqual(
+      get(routingTree, "answer.options[0].id")
+    );
+
+    await updateRoutingConditionValueMutation(routingTree.routingConditionId);
+
+    routingStructure = await getFullRoutingTree(firstPage);
+
+    routingConditions = get(
+      routingStructure,
+      "data.questionPage.routingRuleSet.routingRules[0].conditions"
+    );
+
+    expect(get(first(routingConditions), "routingValue.value")).toBeNull();
+  });
+
+  it("should delete routing condition value when answer is updated", async () => {
+    const routingTree = await createFullRoutingTree(firstPage);
+
+    await updateRoutingConditionValueMutation(
+      routingTree.routingConditionId,
+      first(routingTree.answer.options).id
+    );
+
+    let routingStructure = await getFullRoutingTree(firstPage);
+
+    let routingCondition = get(
+      routingStructure,
+      "data.questionPage.routingRuleSet.routingRules[0].conditions[0]"
+    );
+
+    expect(get(routingCondition, "routingValue.value")).toEqual(
+      first(routingTree.answer.options).id
+    );
+
+    await changeRoutingCondition(
+      firstPage,
+      routingTree.answer,
+      routingTree.routingConditionId
+    );
+
+    routingStructure = await getFullRoutingTree(firstPage);
+    routingCondition = get(
+      routingStructure,
+      "data.questionPage.routingRuleSet.routingRules[0].conditions[0]"
+    );
+
+    expect(get(routingCondition, "routingValue.value")).toBeNull();
+  });
+
+  it("should return available routing destinations", async () => {
+    const secondSection = await createSection(questionnaire.id);
+    await createQuestionPage(get(sections, "[0].id"));
+    await createQuestionPage(get(sections, "[0].id"));
+    await createQuestionPage(secondSection.data.createSection.id);
+    const result = await executeQuery(
+      getAvailableRoutingDestinations,
+      {
+        id: firstPage.id
+      },
+      ctx
+    );
+
+    const destinations = get(result, "data.availableRoutingDestinations");
+
+    expect(get(destinations, "logicalDestinations")).toHaveLength(2);
+    expect(get(destinations, "questionPages")).toHaveLength(2);
+    expect(get(destinations, "sections")).toHaveLength(1);
+  });
+
+  describe("routing", () => {
+    const mutate = async input => createNewRoutingRule(input);
+    const newRoutingRule = async input =>
+      mutate(input).then(res => res.data.createRoutingRule);
+    const addPage = async sectionId =>
+      createQuestionPage(sectionId).then(res => res.data.createQuestionPage);
+    const addSection = async questionnaireId =>
+      createSection(questionnaireId).then(res => res.data.createSection);
+    const getRoutingDataForPage = async page =>
+      getFullRoutingTree(page).then(res => res.data.questionPage);
+    const deleteRoutingRule = async input => deleteRoutingRuleMutation(input);
+
+    describe("routing rule sets", () => {
+      it("should default else to next page", async () => {
+        const routingRuleSet = await createNewRoutingRuleSet(firstPage.id);
+        expect(routingRuleSet).toMatchObject({
+          data: {
+            createRoutingRuleSet: {
+              else: {
+                logicalDestination: "NextPage"
+              }
+            }
+          }
+        });
+      });
+
+      it("should update else to end of questionnaire", async () => {
+        const routingRuleSet = await createNewRoutingRuleSet(firstPage.id);
+
+        const updated = await updateRoutingRuleSetMutation({
+          id: get(routingRuleSet, "data.createRoutingRuleSet.id"),
+          else: {
+            logicalDestination: {
+              destinationType: "EndOfQuestionnaire"
+            }
+          }
+        });
+
+        expect(updated).toMatchObject({
+          data: {
+            updateRoutingRuleSet: {
+              else: {
+                logicalDestination: "EndOfQuestionnaire"
+              }
+            }
+          }
+        });
+      });
+
+      it("should update else to question page", async () => {
+        const routingRuleSet = await createNewRoutingRuleSet(firstPage.id);
+        const section = first(sections);
+        const newPage = await addPage(section.id);
+
+        const updated = await updateRoutingRuleSetMutation({
+          id: get(routingRuleSet, "data.createRoutingRuleSet.id"),
+          else: {
+            absoluteDestination: {
+              destinationType: "QuestionPage",
+              destinationId: `${newPage.id}`
+            }
+          }
+        });
+
+        expect(updated).toMatchObject({
+          data: {
+            updateRoutingRuleSet: {
+              else: {
+                absoluteDestination: newPage
+              }
+            }
+          }
+        });
+      });
+
+      it("should update else to section", async () => {
+        const routingRuleSet = await createNewRoutingRuleSet(firstPage.id);
+        const newSection = await addSection(questionnaire.id);
+
+        const updated = await updateRoutingRuleSetMutation({
+          id: get(routingRuleSet, "data.createRoutingRuleSet.id"),
+          else: {
+            absoluteDestination: {
+              destinationType: "Section",
+              destinationId: `${newSection.id}`
+            }
+          }
+        });
+
+        expect(updated).toMatchObject({
+          data: {
+            updateRoutingRuleSet: {
+              else: {
+                absoluteDestination: newSection
+              }
+            }
+          }
+        });
+      });
+    });
+
+    describe("routing rules", () => {
+      let input;
+
+      beforeEach(async () => {
+        const routingRuleSet = await createNewRoutingRuleSet(firstPage.id).then(
+          result => result.data.createRoutingRuleSet
+        );
+        input = {
+          operation: "And",
+          routingRuleSetId: routingRuleSet.id
+        };
+      });
+
+      it("should default goto next page", async () => {
+        const routingRule = await newRoutingRule(input);
+
+        expect(routingRule).toMatchObject({
+          goto: {
+            logicalDestination: "NextPage"
+          }
+        });
+      });
+
+      it("should create a routing rule that routes to a question page", async () => {
+        const section = first(sections);
+        const newPage = await addPage(section.id);
+        const routingRule = await newRoutingRule(input);
+
+        const result = await updateRoutingRuleMutation(
+          "QuestionPage",
+          newPage.id,
+          routingRule.id
+        );
+
+        expect(result).toMatchObject({
+          data: {
+            updateRoutingRule: {
+              goto: {
+                absoluteDestination: {
+                  id: newPage.id,
+                  __typename: "QuestionPage"
+                }
+              }
+            }
+          }
+        });
+      });
+
+      it("create a routing rule that routes to another section", async () => {
+        const newSection = await addSection(questionnaire.id);
+        const routingRule = await newRoutingRule(input);
+
+        const result = await updateRoutingRuleMutation(
+          "Section",
+          newSection.id,
+          routingRule.id
+        );
+
+        expect(result).toMatchObject({
+          data: {
+            updateRoutingRule: {
+              goto: {
+                absoluteDestination: {
+                  id: newSection.id,
+                  __typename: "Section"
+                }
+              }
+            }
+          }
+        });
+      });
+
+      it("should create a condition for newly created routing rule", async () => {
+        const routingRule = await newRoutingRule(input);
+        expect(get(routingRule, "conditions")).toHaveLength(1);
+      });
+
+      it("should be possible to delete a routing rule", async () => {
+        const routingRule = await newRoutingRule(input);
+        const page = await getRoutingDataForPage(firstPage);
+        expect(page.routingRuleSet.routingRules).toHaveLength(2);
+
+        await deleteRoutingRule({
+          id: routingRule.id
+        });
+
+        const updated = await getRoutingDataForPage(firstPage);
+        expect(updated.routingRuleSet.routingRules).toHaveLength(1);
+      });
+    });
+
+    describe("routing conditions", () => {
+      let input;
+
+      const newCondition = input =>
+        createNewRoutingCondition(input).then(
+          res => res.data.createRoutingCondition
+        );
+
+      beforeEach(async () => {
+        const routingRuleSet = await createNewRoutingRuleSet(firstPage.id).then(
+          res => res.data.createRoutingRuleSet
+        );
+        input = {
+          comparator: "Equal",
+          questionPageId: firstPage.id,
+          routingRuleId: get(routingRuleSet, "routingRules[0].id")
+        };
+      });
+
+      it("should create a routing condition for question page", async () => {
+        const newRoutingCondition = await newCondition(input);
+        expect(newRoutingCondition).toMatchObject({
+          questionPage: {
+            id: firstPage.id
+          }
+        });
+      });
+
+      it("should set question page to null when page deleted", async () => {
+        /*
+          Given two pages A and B
+          And B has a routing condition that refers to A
+          When A is deleted
+          Then B's routing condition page should be null
+         */
+        const pageA = firstPage;
+        const pageB = await createQuestionPage(first(sections).id).then(
+          res => res.data.createQuestionPage
+        );
+
+        await createNewRoutingRuleSet(pageB.id);
+        const routingInfo = await getFullRoutingTree(pageB);
+        const routingCondition = get(
+          routingInfo,
+          "data.questionPage.routingRuleSet.routingRules[0].conditions[0]"
+        );
+        await changeRoutingConditionMutation({
+          id: routingCondition.id,
+          questionPageId: pageA.id
+        });
+
+        await deleteQuestionPage(pageA);
+
+        const updatedRoutingInfo = await getFullRoutingTree(pageB);
+        const updatedRoutingCondition = get(
+          updatedRoutingInfo,
+          "data.questionPage.routingRuleSet.routingRules[0].conditions[0]"
+        );
+
+        expect(updatedRoutingCondition).toMatchObject({
+          questionPage: null,
+          answer: null
+        });
+      });
+
+      it("should set condition answer to null when answer is deleted", async () => {
+        /*
+          Given two pages A and B
+          And B has a routing condition that refers to an answer on page A
+          When the answer from page A is deleted
+          Then B's routing condition answer should be null
+         */
+        const pageA = firstPage;
+        const answer = await createNewAnswer(pageA, "Checkbox");
+
+        const pageB = await createQuestionPage(first(sections).id).then(
+          res => res.data.createQuestionPage
+        );
+
+        await createNewRoutingRuleSet(pageB.id);
+        const routingInfo = await getFullRoutingTree(pageB);
+        const routingCondition = get(
+          routingInfo,
+          "data.questionPage.routingRuleSet.routingRules[0].conditions[0]"
+        );
+        await changeRoutingConditionMutation({
+          id: routingCondition.id,
+          questionPageId: pageA.id,
+          answerId: answer.id
+        });
+
+        await deleteAnswer(answer);
+
+        const updatedRoutingInfo = await getFullRoutingTree(pageB);
+        const updatedRoutingCondition = get(
+          updatedRoutingInfo,
+          "data.questionPage.routingRuleSet.routingRules[0].conditions[0]"
+        );
+
+        expect(updatedRoutingCondition).toMatchObject({
+          questionPage: null,
+          answer: null
+        });
+      });
+
+      it("should remove routing condition values when option is deleted", async () => {
+        /*
+          Given a page with a routing condition that points to a checkbox answer
+          And one of the options is toggled on at the routing condition
+          When the option is deleted
+          Then the routing condition value for the deleted option should also be deleted
+         */
+        const answer = await createNewAnswer(firstPage, "Radio");
+        await createNewRoutingRuleSet(firstPage.id);
+
+        const options = get(answer, "options");
+
+        const routingInfo = await getFullRoutingTree(firstPage);
+        const routingCondition = get(
+          routingInfo,
+          "data.questionPage.routingRuleSet.routingRules[0].conditions[0]"
+        );
+
+        await changeRoutingConditionMutation({
+          id: routingCondition.id,
+          questionPageId: firstPage.id,
+          answerId: answer.id
+        });
+
+        await updateRoutingConditionValueMutation(
+          routingCondition.id,
+          options[0].id
+        );
+
+        const beforeDeletion = await getFullRoutingTree(firstPage);
+        let conditionValues = get(
+          beforeDeletion,
+          "data.questionPage.routingRuleSet.routingRules[0].conditions[0].routingValue.value"
+        );
+        expect(conditionValues).toEqual(options[0].id);
+
+        await deleteOption(options[0]);
+
+        const afterDeletion = await getFullRoutingTree(firstPage);
+        conditionValues = get(
+          afterDeletion,
+          "data.questionPage.routingRuleSet.routingRules[0].conditions[0].routingValue.value"
+        );
+        expect(conditionValues).toBeNull();
+      });
+
+      it("should delete a routing condition for question page", async () => {
+        const newRoutingCondition = await newCondition(input);
+        const page = await getRoutingDataForPage(firstPage);
+        expect(
+          get(page, "routingRuleSet.routingRules[0].conditions")
+        ).toHaveLength(2);
+
+        await deleteRoutingConditionMutation({ id: newRoutingCondition.id });
+
+        const updated = await getRoutingDataForPage(firstPage);
+        expect(
+          get(updated, "routingRuleSet.routingRules[0].conditions")
+        ).toHaveLength(1);
+      });
+
+      it("should set condition to first answer in page if one exists", async () => {
+        const answer = await createNewAnswer(firstPage, "Checkbox");
+        const routingCondition = await newCondition(input);
+
+        expect(routingCondition).toMatchObject({
+          answer: {
+            id: answer.id
+          }
+        });
+      });
+
+      it("should always use first answer on page when creating a condition", async () => {
+        const answer1 = await createNewAnswer(firstPage, "Number");
+        await createNewAnswer(firstPage, "Checkbox");
+        const routingCondition = await newCondition(input);
+
+        expect(routingCondition).toMatchObject({
+          answer: {
+            id: answer1.id
+          }
+        });
+      });
+
+      it("should be possible to change the page for the condition", async () => {
+        const section = first(sections);
+        const page = await getRoutingDataForPage(firstPage);
+
+        const routingCondition = get(
+          page,
+          "routingRuleSet.routingRules[0].conditions[0]"
+        );
+        expect(routingCondition).toMatchObject({
+          questionPage: {
+            id: firstPage.id
+          }
+        });
+
+        const newPage = await addPage(section.id);
+
+        await changeRoutingConditionMutation({
+          id: routingCondition.id,
+          questionPageId: newPage.id
+        });
+
+        const updated = await getRoutingDataForPage(firstPage);
+        expect(
+          get(updated, "routingRuleSet.routingRules[0].conditions[0]")
+        ).toMatchObject({
+          questionPage: {
+            id: newPage.id
+          }
+        });
+      });
+
+      describe("routing condition values", () => {
+        it("should only be possible to select one option per condition", async () => {
+          // Given a checkbox with two options 1 and 2
+          // When I toggle the first option
+          // Then the routing condition value should be equal to the first option Id
+          // When I toggle the second option
+          // Then the routing condition value should equal the second option Id
+
+          const routingTree = await createFullRoutingTree(firstPage);
+          const checkboxAnswer = get(routingTree, "answer");
+          const option1 = first(checkboxAnswer.options);
+          const option2 = await createOption(checkboxAnswer.id).then(
+            res => res.data.createOption
+          );
+          const { routingConditionId } = routingTree;
+
+          const res = await updateRoutingConditionValueMutation(
+            routingConditionId,
+            option1.id
+          );
+
+          expect(res).toMatchObject({
+            data: {
+              updateRoutingConditionValue: {
+                value: option1.id
+              }
+            }
+          });
+
+          const res2 = await updateRoutingConditionValueMutation(
+            routingConditionId,
+            option2.id
+          );
+
+          expect(res2).toMatchObject({
+            data: {
+              updateRoutingConditionValue: {
+                value: option2.id
+              }
+            }
+          });
+        });
+
+        it("should unset an routing condition answer by setting optionId to null", async () => {
+          const routingTree = await createFullRoutingTree(firstPage);
+          const { routingConditionId } = routingTree;
+          const result = await updateRoutingConditionValueMutation(
+            routingConditionId
+          );
+          expect(result.data).toMatchObject({
+            updateRoutingConditionValue: {
+              value: null
+            }
+          });
+        });
+      });
+    });
   });
 });

--- a/schema/resolvers.test.js
+++ b/schema/resolvers.test.js
@@ -240,7 +240,10 @@ const deleteRoutingConditionMutation = async input =>
     ctx
   );
 
-const updateRoutingConditionValueMutation = async (conditionId, optionId) =>
+const updateRoutingConditionValueMutation = async (
+  conditionId,
+  optionId = null
+) =>
   executeQuery(
     updateRoutingConditionValue,
     {

--- a/tests/utils/graphql.js
+++ b/tests/utils/graphql.js
@@ -16,6 +16,69 @@ const createQuestionnaireMutation = `mutation CreateQuestionnaire($input: Create
   }
 `;
 
+const createSectionMutation = `
+  mutation CreateSection($input: CreateSectionInput!){
+    createSection(input: $input){
+      id
+    }
+  }
+`;
+
+const deletePageMutation = `
+  mutation DeletePage($input: DeletePageInput!){
+    deletePage(input: $input){
+      id
+    }
+  }
+`;
+
+const deleteAnswerMutation = `
+mutation DeleteAnswer($input: DeleteAnswerInput!){
+  deleteAnswer(input: $input){
+    id
+  }
+}
+`;
+
+const deleteOptionMutation = `
+mutation DeleteOption($input: DeleteOptionInput!){
+  deleteOption(input: $input){
+    id
+  }
+}
+`;
+
+const createOptionMutation = `
+mutation CreateOption($input: CreateOptionInput!){
+  createOption(input: $input){
+    id
+  }
+}
+`;
+
+const createQuestionPageMutation = `
+  mutation CreateQuestionPage($input: CreateQuestionPageInput!){
+    createQuestionPage(input: $input){
+      id
+    }
+  }
+`;
+
+const getPageQuery = `
+  query GetQuestionPage($id: ID!){
+    questionPage(id:$id){
+      id
+      guidance
+      description
+      pageType
+      position
+      section{
+        id
+      }
+    }
+  }
+`;
+
 const createAnswerMutation = `
   mutation CreateAnswer($input: CreateAnswerInput!) {
     createAnswer(input: $input) {
@@ -116,11 +179,330 @@ const getAnswersQuery = `
   }
 `;
 
+const getBasicRoutingQuery = `
+query GetPage($id: ID!){
+  page(id: $id){
+    ...on QuestionPage{
+      id
+      routingRuleSet{
+        id
+        questionPage{
+          id
+        }
+        routingRules{
+          id
+          conditions{
+            id
+            routingValue{
+              ...on IDValue{
+                value
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
+const createRoutingRuleSet = `
+  mutation CreateRoutingRuleSet($input: CreateRoutingRuleSetInput!){
+    createRoutingRuleSet(input: $input)
+    {
+      id
+      questionPage{
+        id
+      }
+      routingRules{
+        id
+      }
+      else {
+        ... on LogicalDestination {
+          logicalDestination
+        }
+      }
+    }
+  }
+`;
+
+const createRoutingRule = `
+  mutation CreateRoutingRule($input: CreateRoutingRuleInput!){
+    createRoutingRule(input: $input)
+    {
+      id
+      operation
+      conditions {
+        id
+      }
+      goto {
+        ... on LogicalDestination {
+          logicalDestination
+        }
+        ... on AbsoluteDestination {
+          absoluteDestination {
+            ...on QuestionPage{
+              id
+              section{
+                id
+              }
+            }
+            ...on Section{
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const createRoutingCondition = `
+  mutation CreateRoutingCondition($input: CreateRoutingConditionInput!){
+    createRoutingCondition(input: $input)
+    {
+      id
+      comparator
+      questionPage {
+        id
+      }
+      answer {
+        id
+      }
+      routingValue {
+        ... on IDValue {
+          value
+        }
+      }
+    }
+  }
+`;
+
+const updateRoutingRuleSet = `
+mutation UpdateRoutingRuleSet($input: UpdateRoutingRuleSetInput!){
+  updateRoutingRuleSet (input: $input)
+  {
+    id
+    else {
+      ... on LogicalDestination {
+        logicalDestination
+      }
+      ... on AbsoluteDestination {
+        absoluteDestination {
+          ...on QuestionPage{
+            id
+            section{
+              id
+            }
+          }
+          ...on Section{
+            id
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
+const deleteRoutingRuleSet = `
+mutation DeleteRoutingRuleSet($input: DeleteRoutingRuleSetInput!) {
+  deleteRoutingRuleSet(input: $input) {
+    id
+  }
+}
+`;
+
+const updateRoutingRule = `
+mutation UpdateRoutingRule($input: UpdateRoutingRuleInput!){
+  updateRoutingRule (input: $input)
+  {
+    id
+    goto {
+      ... on LogicalDestination {
+        logicalDestination
+      }
+      ... on AbsoluteDestination {
+        absoluteDestination {
+          __typename
+          ...on QuestionPage{
+            id
+            section{
+              id
+            }
+          }
+          ...on Section{
+            id
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
+const updateCondition = `
+mutation($input: UpdateRoutingConditionInput!){
+  updateRoutingCondition (input: $input)
+  {
+    id
+  }
+}
+`;
+
+const deleteRoutingRule = `
+  mutation($input: DeleteRoutingRuleInput!) {
+    deleteRoutingRule(input: $input) {
+      id
+    }
+  }
+`;
+
+const deleteRoutingCondition = `
+  mutation($input: DeleteRoutingConditionInput!) {
+    deleteRoutingCondition(input: $input) {
+      id
+    }
+  }
+`;
+
+const updateRoutingConditionValue = `
+  mutation($input: UpdateRoutingConditionValueInput!) {
+    updateRoutingConditionValue (input: $input)
+    {
+      ...on IDValue{
+        value
+      }
+    }
+  }
+`;
+
+const getEntireRoutingStructure = `
+query QuestionPage($id: ID!) {
+  questionPage(id: $id) {
+    routingRuleSet {
+      id
+      questionPage {
+        id
+      }
+      else {
+        ... on LogicalDestination {
+          logicalDestination
+        }
+        ... on AbsoluteDestination {
+          absoluteDestination {
+            ...on QuestionPage{
+              id
+              section{
+                id
+              }
+            }
+            ...on Section{
+              id
+            }
+          }
+        }
+      }
+      routingRules {
+        id
+        operation
+        goto {
+          ... on LogicalDestination {
+            logicalDestination
+          }
+          ... on AbsoluteDestination {
+            absoluteDestination {
+              ...on QuestionPage{
+                id
+                section{
+                  id
+                }
+              }
+              ...on Section{
+                id
+              }
+            }
+          }
+        }
+        conditions {
+          id
+          comparator
+          questionPage {
+            id
+          }
+          answer {
+            id
+          }
+          routingValue {
+            ...on IDValue {
+              value
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
+const getAvailableRoutingDestinations = `
+query QuestionPage($id: ID!) {
+  availableRoutingDestinations(pageId: $id) {
+    ... on AvailableRoutingDestinations {
+      logicalDestinations {
+        logicalDestination
+      }
+      questionPages {
+        id
+      }
+      sections {
+        id
+      }
+    }
+  }
+}
+`;
+
+const getQuestionnaire = `
+query QuestionPage($id: ID!) {
+  questionnaire(id: $id) {
+  	id
+    sections{
+      id
+      pages{
+        id
+      }
+    }
+  }
+}
+`;
+
 module.exports = {
   createQuestionnaireMutation,
   createAnswerMutation,
   createOtherMutation,
   deleteOtherMutation,
   getAnswerQuery,
-  getAnswersQuery
+  getAnswersQuery,
+  createRoutingRuleSet,
+  updateRoutingConditionValue,
+  getEntireRoutingStructure,
+  getBasicRoutingQuery,
+  updateRoutingRule,
+  updateCondition,
+  createSectionMutation,
+  createQuestionPageMutation,
+  getAvailableRoutingDestinations,
+  getQuestionnaire,
+  getPageQuery,
+  updateRoutingRuleSet,
+  createRoutingRule,
+  deleteRoutingRule,
+  createRoutingCondition,
+  deleteRoutingCondition,
+  deleteRoutingRuleSet,
+  deletePageMutation,
+  deleteAnswerMutation,
+  deleteOptionMutation,
+  createOptionMutation
 };

--- a/utils/formatRichText.js
+++ b/utils/formatRichText.js
@@ -1,0 +1,3 @@
+const cheerio = require("cheerio");
+module.exports = (value, format) =>
+  format === "Plaintext" ? cheerio(value).text() : value;

--- a/utils/formatRichText.test.js
+++ b/utils/formatRichText.test.js
@@ -1,0 +1,20 @@
+const formatRichText = require("./formatRichText");
+
+describe("formatRichText", () => {
+  let value;
+
+  beforeEach(() => {
+    value =
+      "<h1>A heading with <strong>bold and <em>italic</em> text within</strong></h1>";
+  });
+
+  it("should return the HTML by default", () => {
+    expect(formatRichText(value)).toEqual(value);
+  });
+
+  it("should return the Plaintext value", () => {
+    expect(formatRichText(value, "Plaintext")).toEqual(
+      "A heading with bold and italic text within"
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1298,9 +1298,9 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-eq-author-graphql-schema@^0.14.2:
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.14.2.tgz#287a51b18ef20c1651c0d60aa0628fd839fa102e"
+eq-author-graphql-schema@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.15.0.tgz#bbd5e17018d1cdf5272e8fabf45cc96e54ad8ca3"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,10 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@types/node@*":
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.1.2.tgz#1b928a0baa408fc8ae3ac012cc81375addc147c6"
+
 "@types/node@^9.4.6":
   version "9.6.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.7.tgz#5f3816d1db2155edcde1b2e3aa5d0e5c520cb564"
@@ -543,6 +547,10 @@ body-parser@^1.17.2:
     raw-body "2.3.1"
     type-is "~1.6.15"
 
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -731,6 +739,17 @@ chalk@^2.0.1, chalk@^2.1.0:
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
+cheerio@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
 
 chokidar@^1.7.0:
   version "1.7.0"
@@ -997,6 +1016,19 @@ crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
 
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
+css-what@2.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
+
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
@@ -1165,11 +1197,46 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-serializer@0, dom-serializer@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+  dependencies:
+    domelementtype "~1.1.1"
+    entities "~1.1.1"
+
+domelementtype@1, domelementtype@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
+
 domexception@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
   dependencies:
     webidl-conversions "^4.0.2"
+
+domhandler@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
+  dependencies:
+    domelementtype "1"
+
+domutils@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
 
 dot-prop@^4.1.0:
   version "4.2.0"
@@ -1227,9 +1294,13 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-eq-author-graphql-schema@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.13.0.tgz#4da073fad2da6173ebc272fd668f6449d1b039f9"
+entities@^1.1.1, entities@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+eq-author-graphql-schema@^0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.14.2.tgz#287a51b18ef20c1651c0d60aa0628fd839fa102e"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
@@ -2226,6 +2297,17 @@ html-encoding-sniffer@^1.0.2:
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
     whatwg-encoding "^1.0.1"
+
+htmlparser2@^3.9.1:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
 
 http-errors@1.6.2, http-errors@~1.6.2:
   version "1.6.2"
@@ -3946,6 +4028,12 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
+nth-check@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
+  dependencies:
+    boolbase "~1.0.0"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -4160,6 +4248,12 @@ parse-passwd@^1.0.0:
 parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  dependencies:
+    "@types/node" "*"
 
 parseurl@~1.3.1:
   version "1.3.2"


### PR DESCRIPTION
### What is the context of this PR?
This PR adds necessary resolvers for the newly introduced GraphQL schema types in order to support basic routing functionality within Author.

Changes include:
 - New migration scripts to create the new database tables.
 - Resolver functions for each of the new GraphQL types for basic routing.
 - Database and transaction logic (Repository, queries etc.)
 - New integration and unit tests covering the core routing logic.
 - New field arguments to support bringing back section and page titles as plaintext.

### How to review 
All checks and tests should pass.
Code review required.

### Dependencies
 - https://github.com/ONSdigital/eq-author-graphql-schema/pull/37
