### PR TITLE
Pin author api to working version of the schema.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^6.0.0",
-    "eq-author-graphql-schema": "^0.15.0",
+    "eq-author-graphql-schema": "0.15.0",
     "express": "^4.15.3",
     "express-pino-logger": "^3.0.1",
     "graphql": "^0.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1298,7 +1298,7 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-eq-author-graphql-schema@^0.15.0:
+eq-author-graphql-schema@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.15.0.tgz#bbd5e17018d1cdf5272e8fabf45cc96e54ad8ca3"
 


### PR DESCRIPTION
### What is the context of this PR?
Author API is failing to deploy in both staging and pre-production environments due to a mismatch in the semantic versions of the graphql schema.

This PR pins the API to a version of the schema known to be working.

### How to review 
API should be pinned to version 0.15.0
All tests and checks should pass.
