### PR TITLE
ensure sections are ordered in availableRoutingDestinations

### DIFF
--- a/repositories/strategies/routingStrategy.js
+++ b/repositories/strategies/routingStrategy.js
@@ -83,6 +83,7 @@ const getSectionDestinations = (trx, { id, questionnaireId }) =>
     .select("*")
     .where(toDb({ questionnaireId, isDeleted: false }))
     .where("id", ">", id)
+    .orderBy("created_at", "asc")
     .then(map(fromDb));
 
 const findRoutingRuleSet = (trx, questionPageId) =>


### PR DESCRIPTION
### What is the context of this PR?
Noticed that occasionally the `Section`s were coming back from `availableRoutingDestinations` in the wrong order. This PR adds an `ORDER BY created_at ASC` clause to the query (since sections have no user-defined order yet).

### How to review 
I had a problem recreating the issue locally. It seems to happen inconsistently on pre-prod, and i'm not sure what circumstances cause it...

This questionnaire _has_ the issue: https://deploy-preview-364--author.netlify.com/#/eq-author/questionnaire/150/424/1578/routing

This questionnaire _does not_ have the issue: https://deploy-preview-364--author.netlify.com/#/eq-author/questionnaire/149/418/1567/routing

However, I think this is the right change and is safe to make regardless (this is how things are ordered in `SectionRepository`)