### PR TITLE
Pin version of eslint-scope package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "knex": "knex --knexfile config/knexfile.js --cwd .",
     "precommit": "lint-staged"
   },
+  "resolutions": {
+    "eslint-scope": "3.7.1"
+  }, 
   "lint-staged": {
     "*.js": [
       "prettier --write",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1450,7 +1450,7 @@ eslint-plugin-react@^7.0.1:
     jsx-ast-utils "^2.0.0"
     prop-types "^15.5.10"
 
-eslint-scope@^3.7.1:
+eslint-scope@3.7.1, eslint-scope@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   dependencies:


### PR DESCRIPTION
### What is the context of this PR?
Version is being pinned due to https://github.com/eslint/eslint-scope/issues/39

### How to review 
Version of eslint-scope should be pinned to 3.7.1
