### PR TITLE
Add move section mutation

### DIFF
--- a/migrations/20180629130216_add_order_to_sections.js
+++ b/migrations/20180629130216_add_order_to_sections.js
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.table("Sections", table => {
+    table
+      .integer("order")
+      .defaultsTo(0)
+      .notNullable();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table("Sections", table => {
+    table.dropColumn("order");
+  });
+};

--- a/migrations/20180629130217_seed_section_order_column.js
+++ b/migrations/20180629130217_seed_section_order_column.js
@@ -1,0 +1,18 @@
+exports.up = function(knex) {
+  return knex.raw(`
+    UPDATE "Sections"
+    SET "order" = s.position
+    FROM (
+      SELECT id, ROW_NUMBER () OVER (
+        PARTITION BY "QuestionnaireId"
+        ORDER BY id
+      ) * 1000 as "position"
+      FROM "Sections"
+    ) s
+    WHERE "Sections".id = s.id
+  `);
+};
+
+exports.down = function(knex) {
+  return knex("Sections").update({ order: 0 });
+};

--- a/migrations/20180711133028_add_view_table_for_sections.js
+++ b/migrations/20180711133028_add_view_table_for_sections.js
@@ -1,0 +1,16 @@
+exports.up = function(knex) {
+  return knex.raw(`
+    CREATE OR REPLACE VIEW "SectionsView" AS (
+      SELECT *, ROW_NUMBER () OVER (
+        PARTITION BY "QuestionnaireId"
+        ORDER BY "order" ASC
+      ) - 1 AS "position"
+      FROM "Sections"
+      WHERE "isDeleted" = false
+    )
+  `);
+};
+
+exports.down = function(knex) {
+  return knex.raw(`DROP VIEW "SectionsView"`);
+};

--- a/repositories/PageRepository.js
+++ b/repositories/PageRepository.js
@@ -4,7 +4,7 @@ const QuestionPageRepository = require("./QuestionPageRepository");
 const mapFields = require("../utils/mapFields");
 const db = require("../db");
 const {
-  getOrUpdateOrderForInsert
+  getOrUpdateOrderForPageInsert
 } = require("./strategies/spacedOrderStrategy");
 
 const {
@@ -45,7 +45,7 @@ function insert(args) {
   const { sectionId, position } = args;
 
   return db.transaction(trx => {
-    return getOrUpdateOrderForInsert(trx, sectionId, null, position)
+    return getOrUpdateOrderForPageInsert(trx, sectionId, null, position)
       .then(order => Object.assign(args, { order }))
       .then(page => repository.insert(page, trx));
   });
@@ -79,7 +79,7 @@ function undelete(id) {
 
 function move({ id, sectionId, position }) {
   return db.transaction(trx => {
-    return getOrUpdateOrderForInsert(trx, sectionId, id, position)
+    return getOrUpdateOrderForPageInsert(trx, sectionId, id, position)
       .then(order => Page.update(id, toDb({ sectionId, order }), trx))
       .then(head)
       .then(fromDb)

--- a/repositories/PageRepository.test.js
+++ b/repositories/PageRepository.test.js
@@ -194,9 +194,10 @@ describe("PagesRepository", () => {
     });
 
     it("can move pages between sections", async () => {
-      const { section } = await setup();
+      const { section, questionnaire: { id: questionnaireId } } = await setup();
+
       const section2 = await SectionRepository.insert(
-        buildSection({ title: "Section 2" })
+        buildSection({ title: "Section 2", questionnaireId })
       );
       const results = await createPages(section.id, 3);
 
@@ -214,9 +215,10 @@ describe("PagesRepository", () => {
     });
 
     it("correctly re-orders pages as they're moved between sections", async () => {
-      const { section } = await setup();
+      const { section, questionnaire: { id: questionnaireId } } = await setup();
+
       const section2 = await SectionRepository.insert(
-        buildSection({ title: "Section 2" })
+        buildSection({ title: "Section 2", questionnaireId })
       );
       const results = await createPages(section.id, 3);
 

--- a/repositories/SectionRepository.test.js
+++ b/repositories/SectionRepository.test.js
@@ -1,0 +1,349 @@
+const db = require("../db");
+const QuestionnaireRepository = require("../repositories/QuestionnaireRepository");
+const SectionRepository = require("../repositories/SectionRepository");
+const { last, head, map, toString, times } = require("lodash");
+
+const reverse = array => array.slice().reverse();
+
+const buildQuestionnaire = questionnaire => ({
+  title: "Test questionnaire",
+  surveyId: "1",
+  theme: "default",
+  legalBasis: "Voluntary",
+  navigation: false,
+  createdBy: "foo",
+  ...questionnaire
+});
+
+const buildSection = section => ({
+  title: "Test section",
+  description: "section description",
+  ...section
+});
+
+const setup = async () => {
+  const questionnaire = await QuestionnaireRepository.insert(
+    buildQuestionnaire()
+  );
+
+  return { questionnaire };
+};
+
+const eachP = (items, iter) =>
+  items.reduce(
+    (promise, item) => promise.then(() => iter(item)),
+    Promise.resolve()
+  );
+
+describe("SectionRepository", () => {
+  beforeAll(() => db.migrate.latest());
+  afterAll(() => db.migrate.rollback().then(() => db.destroy()));
+  afterEach(() => db("Questionnaires").delete());
+
+  it("allows sections to be created", async () => {
+    const {
+      questionnaire: { id: questionnaireId }
+    } = await setup();
+
+    const section = buildSection({ questionnaireId: questionnaireId });
+    const result = await SectionRepository.insert(section);
+
+    expect(result).toMatchObject(section);
+    expect(result.order).not.toBeNull();
+  });
+
+  it("allows sections to be updated", async () => {
+    const {
+      questionnaire: { id: questionnaireId }
+    } = await setup();
+
+    const result = await SectionRepository.insert(
+      buildSection({ questionnaireId: questionnaireId })
+    );
+
+    await SectionRepository.update({
+      id: result.id,
+      title: "updated title",
+      description: "updated description"
+    });
+    const updated = await SectionRepository.getById(result.id);
+
+    expect(updated.title).not.toEqual(result.title);
+  });
+
+  it("allow sections to be deleted", async () => {
+    const {
+      questionnaire: { id: questionnaireId }
+    } = await setup();
+    const section = await SectionRepository.insert(
+      buildSection({ questionnaireId: questionnaireId })
+    );
+
+    await SectionRepository.remove(section.id);
+    const result = await SectionRepository.getById(section.id);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("allows sections to be un-deleted", async () => {
+    const {
+      questionnaire: { id: questionnaireId }
+    } = await setup();
+
+    const section = await SectionRepository.insert(
+      buildSection({ questionnaireId: questionnaireId })
+    );
+
+    await SectionRepository.remove(section.id);
+    await SectionRepository.undelete(section.id);
+
+    const result = await SectionRepository.getById(section.id);
+    expect(result).toMatchObject(section);
+  });
+
+  it("can get section position", async () => {
+    const {
+      questionnaire: { id: questionnaireId }
+    } = await setup();
+
+    const result = await SectionRepository.insert(
+      buildSection({ questionnaireId: questionnaireId })
+    );
+
+    const position = await SectionRepository.getPosition(result);
+    expect(position).toEqual("0");
+  });
+
+  describe("re-ordering", () => {
+    const createSections = (questionnaireId, numberOfPages) => {
+      const sections = times(numberOfPages, i =>
+        buildSection({ title: `Section ${i}`, questionnaireId })
+      );
+
+      return eachP(sections, SectionRepository.insert).then(() =>
+        SectionRepository.findAll({ questionnaireId })
+      );
+    };
+
+    it("should add sections in correct order", async () => {
+      const {
+        questionnaire: { id: questionnaireId }
+      } = await setup();
+
+      const results = await createSections(questionnaireId, 5);
+
+      expect(results).toHaveLength(5);
+
+      results.forEach((result, i) => {
+        expect(result).toMatchObject({ title: `Section ${i}` });
+        expect(result.position).toEqual(toString(i));
+      });
+    });
+
+    it("can move sections within a questionnaire", async () => {
+      const {
+        questionnaire: { id: questionnaireId }
+      } = await setup();
+
+      const sections = await createSections(questionnaireId, 5);
+
+      // reverse the list
+      await eachP(sections, ({ id, questionnaireId }) =>
+        SectionRepository.move({
+          id: id,
+          questionnaireId: questionnaireId,
+          position: 0
+        })
+      );
+
+      const updatedSections = await SectionRepository.findAll({
+        questionnaireId
+      });
+
+      expect(map(updatedSections, "id")).toEqual(map(reverse(sections), "id"));
+    });
+
+    it("gracefully handles position values greater than number of pages", async () => {
+      const {
+        questionnaire: { id: questionnaireId }
+      } = await setup();
+
+      const results = await createSections(questionnaireId, 5);
+
+      await SectionRepository.move({
+        id: head(results).id,
+        questionnaireId: questionnaireId,
+        position: 10
+      });
+
+      const updatedResults = await SectionRepository.findAll({
+        questionnaireId: questionnaireId
+      });
+
+      expect(last(updatedResults).id).toBe(head(results).id);
+    });
+
+    it("gracefully handles position values less than zero", async () => {
+      const {
+        questionnaire: { id: questionnaireId }
+      } = await setup();
+
+      const results = await createSections(questionnaireId, 5);
+
+      await SectionRepository.move({
+        id: last(results).id,
+        questionnaireId: questionnaireId,
+        position: -100
+      });
+
+      const updatedResults = await SectionRepository.findAll({
+        questionnaireId: questionnaireId
+      });
+
+      expect(head(updatedResults).id).toBe(last(results).id);
+    });
+
+    it("reorders sections correctly even when there are deleted sections", async () => {
+      const {
+        questionnaire: { id: questionnaireId }
+      } = await setup();
+
+      const sections = await createSections(questionnaireId, 3);
+
+      await SectionRepository.remove(sections[1].id);
+
+      const newSection = await SectionRepository.insert(
+        buildSection({ title: "new section", questionnaireId: questionnaireId })
+      );
+
+      await SectionRepository.move({
+        id: newSection.id,
+        questionnaireId: questionnaireId,
+        position: 0
+      });
+
+      const updatedResults = await SectionRepository.findAll({
+        questionnaireId: questionnaireId
+      });
+
+      expect(updatedResults).not.toContainEqual(
+        expect.objectContaining({ id: sections[1].id })
+      );
+
+      expect(map(updatedResults, "id")).toEqual(
+        map([newSection, sections[0], sections[2]], "id")
+      );
+    });
+
+    it("returns deleted section to correct position when un-deleted ", async () => {
+      const {
+        questionnaire: { id: questionnaireId }
+      } = await setup();
+
+      const sections = await createSections(questionnaireId, 5);
+
+      await SectionRepository.remove(sections[3].id);
+
+      await SectionRepository.move({
+        id: sections[4].id,
+        questionnaireId: questionnaireId,
+        position: 2
+      });
+
+      await SectionRepository.undelete(sections[3].id);
+
+      const updatedResults = await SectionRepository.findAll({
+        questionnaireId: questionnaireId
+      });
+
+      expect(map(updatedResults, "id")).toEqual(
+        map(
+          [sections[0], sections[1], sections[4], sections[2], sections[3]],
+          "id"
+        )
+      );
+    });
+
+    it("allow insertion at specific position", async () => {
+      const {
+        questionnaire: { id: questionnaireId }
+      } = await setup();
+
+      const section1 = await SectionRepository.insert(
+        buildSection({ questionnaireId: questionnaireId, position: 0 })
+      );
+      const section2 = await SectionRepository.insert(
+        buildSection({ questionnaireId: questionnaireId, position: 0 })
+      );
+      const section3 = await SectionRepository.insert(
+        buildSection({ questionnaireId: questionnaireId, position: 0 })
+      );
+      const section4 = await SectionRepository.insert(
+        buildSection({ questionnaireId: questionnaireId, position: 0 })
+      );
+      const section5 = await SectionRepository.insert(
+        buildSection({ questionnaireId: questionnaireId, position: 0 })
+      );
+
+      const updatedResults = await SectionRepository.findAll({
+        questionnaireId: questionnaireId
+      });
+
+      expect(map(updatedResults, "id")).toEqual(
+        map([section5, section4, section3, section2, section1], "id")
+      );
+    });
+
+    it("allows insertion at middle of list", async () => {
+      const {
+        questionnaire: { id: questionnaireId }
+      } = await setup();
+
+      const section1 = await SectionRepository.insert(
+        buildSection({ questionnaireId: questionnaireId, position: 0 })
+      );
+      const section2 = await SectionRepository.insert(
+        buildSection({ questionnaireId: questionnaireId, position: 1 })
+      );
+      const section3 = await SectionRepository.insert(
+        buildSection({ questionnaireId: questionnaireId, position: 2 })
+      );
+
+      await SectionRepository.move({
+        id: section3.id,
+        questionnaireId: questionnaireId,
+        position: 1
+      });
+
+      const updatedResults = await SectionRepository.findAll({
+        questionnaireId: questionnaireId
+      });
+
+      expect(map(updatedResults, "id")).toEqual(
+        map([section1, section3, section2], "id")
+      );
+    });
+
+    it("correctly inserts at end of list", async () => {
+      const {
+        questionnaire: { id: questionnaireId }
+      } = await setup();
+
+      const sections = await createSections(questionnaireId, 3);
+
+      await eachP(reverse(sections), section =>
+        SectionRepository.move({
+          id: section.id,
+          questionnaireId: questionnaireId,
+          position: 2
+        })
+      );
+
+      const updatedResults = await SectionRepository.findAll({
+        questionnaireId: questionnaireId
+      });
+
+      expect(map(updatedResults, "id")).toEqual(map(reverse(sections), "id"));
+    });
+  });
+});

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -67,6 +67,7 @@ const Resolvers = {
       ctx.repositories.Section.remove(args.input.id),
     undeleteSection: (_, args, ctx) =>
       ctx.repositories.Section.undelete(args.input.id),
+    moveSection: (_, args, ctx) => ctx.repositories.Section.move(args.input),
 
     createPage: (root, args, ctx) => ctx.repositories.Page.insert(args.input),
 
@@ -182,7 +183,13 @@ const Resolvers = {
       ctx.repositories.Page.findAll({ SectionId: section.id }),
     questionnaire: (section, args, ctx) =>
       ctx.repositories.Questionnaire.getById(section.questionnaireId),
-    title: (page, args) => formatRichText(page.title, args.format)
+    title: (page, args) => formatRichText(page.title, args.format),
+    position: ({ position, id }, args, ctx) => {
+      if (position !== undefined) {
+        return position;
+      }
+      return ctx.repositories.Section.getPosition({ id });
+    }
   },
 
   Page: {

--- a/tests/utils/graphql.js
+++ b/tests/utils/graphql.js
@@ -528,6 +528,16 @@ mutation UpdateAnswer($input: UpdateAnswerInput!) {
 }
 `;
 
+const moveSectionMutation = `
+mutation MoveSection($input: MoveSectionInput!) {
+  moveSection(input: $input) {
+    id
+    position
+    __typename
+  }
+}
+`;
+
 module.exports = {
   getPipableAnswersQuery,
   createQuestionnaireMutation,
@@ -557,5 +567,6 @@ module.exports = {
   deletePageMutation,
   deleteAnswerMutation,
   deleteOptionMutation,
-  createOptionMutation
+  createOptionMutation,
+  moveSectionMutation
 };


### PR DESCRIPTION
### What is the context of this PR?

- Implements functionality required to re-order and move sections within a questionnaire

### How to review 
- Run Tests
- Use eQ Author GraphQL API explorer to test mutations and queries eg.
```
mutation MoveSection($input: MoveSectionInput!) {
  moveSection(input: $input) {
    id
    position
    __typename
  }
}

#Query Variables
{
  "input": {
    "id": "1",
    "questionnaireId": "1",
    "position": 2
  }
}
```