### PR TITLE
Add query resolver to get total number of sections in a questionnaire

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^6.0.0",
-    "eq-author-graphql-schema": "0.18.0",
+    "eq-author-graphql-schema": "0.19.0",
     "express": "^4.15.3",
     "express-pino-logger": "^3.0.1",
     "graphql": "^0.13.2",

--- a/repositories/SectionRepository.js
+++ b/repositories/SectionRepository.js
@@ -81,3 +81,11 @@ module.exports.move = function({ id, questionnaireId, position }) {
 module.exports.getPosition = function({ id }) {
   return this.getById(id).then(get("position"));
 };
+
+module.exports.getSectionCount = function getSectionCount(questionnaireId) {
+  return db("SectionsView")
+    .count()
+    .where({ QuestionnaireId: questionnaireId })
+    .then(head)
+    .then(get("count"));
+};

--- a/repositories/SectionRepository.test.js
+++ b/repositories/SectionRepository.test.js
@@ -114,6 +114,17 @@ describe("SectionRepository", () => {
     expect(position).toEqual("0");
   });
 
+  it("can get section count ", async () => {
+    const {
+      questionnaire: { id: questionnaireId }
+    } = await setup();
+
+    await SectionRepository.insert(buildSection({ questionnaireId }));
+
+    const count = await SectionRepository.getSectionCount(questionnaireId);
+    expect(count).toEqual("1");
+  });
+
   describe("re-ordering", () => {
     const createSections = (questionnaireId, numberOfPages) => {
       const sections = times(numberOfPages, i =>

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -175,7 +175,13 @@ const Resolvers = {
   Questionnaire: {
     sections: (questionnaire, args, ctx) =>
       ctx.repositories.Section.findAll({ QuestionnaireId: questionnaire.id }),
-    createdBy: questionnaire => ({ name: questionnaire.createdBy })
+    createdBy: questionnaire => ({ name: questionnaire.createdBy }),
+    questionnaireInfo: ({ id }) => id
+  },
+
+  QuestionnaireInfo: {
+    totalSectionCount: (questionnaireId, args, ctx) =>
+      ctx.repositories.Section.getSectionCount(questionnaireId)
   },
 
   Section: {

--- a/schema/resolvers.test.js
+++ b/schema/resolvers.test.js
@@ -740,6 +740,37 @@ describe("resolvers", () => {
     expect(result).toMatchObject(expected);
   });
 
+  it("should get total number of sections", async () => {
+    const getTotalSectionCountQuery = `
+     query GetTotalSectionCount($id: ID!) {
+        questionnaire(id: $id) {
+          questionnaireInfo {
+            totalSectionCount
+          }
+        }
+      }
+      `;
+
+    const result = await executeQuery(
+      getTotalSectionCountQuery,
+      {
+        id: questionnaire.id
+      },
+      ctx
+    );
+
+    const expected = {
+      data: {
+        questionnaire: {
+          questionnaireInfo: {
+            totalSectionCount: 1
+          }
+        }
+      }
+    };
+    expect(result).toMatchObject(expected);
+  });
+
   describe("routing", () => {
     const mutate = async input => createNewRoutingRule(input);
     const newRoutingRule = async input =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,9 +1297,9 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-eq-author-graphql-schema@0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.18.0.tgz#6ed6a26a3d57f059c7fa68c7065d706f93eb0aa1"
+eq-author-graphql-schema@0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.19.0.tgz#2f262270682f1d5bbb88f82752579cb00bf3cc1f"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
### What is the context of this PR?
- Resolves new type `QuestionnaireInfo` which returns total number of sections in a questionnaire
- This is needed to be able to disable/enable the 'Move Section' button on the UI to based on the number of sections in a questionnaire.
- https://trello.com/c/18p5lgJP/533-disable-move-section-button-if-there-is-only-one-section

### How to review
- Run Tests
- Use eQ Author GraphQL API explorer to query QuestionnaireInfo eg.
```
query GetTotalSectionCount($id: ID!) {
  questionnaire(id: $id) {
    questionnaireInfo {
      totalSectionCount
    }
  }
}

#Query Variables
{
  "id": 1
}
```