### PR TITLE
Upgrade schema and stop adding section description content

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^6.0.0",
-    "eq-author-graphql-schema": "0.19.0",
+    "eq-author-graphql-schema": "0.20.0",
     "express": "^4.15.3",
     "express-pino-logger": "^3.0.1",
     "graphql": "^0.13.2",

--- a/repositories/SectionRepository.js
+++ b/repositories/SectionRepository.js
@@ -38,7 +38,7 @@ module.exports.insert = function insert(args) {
       position
     )
       .then(order => Object.assign(args, { order }))
-      .then(pick(["title", "description", "questionnaireId", "order"]))
+      .then(pick(["title", "questionnaireId", "order"]))
       .then(toDb)
       .then(section => Section.create(section, trx))
       .then(head)
@@ -46,10 +46,9 @@ module.exports.insert = function insert(args) {
   });
 };
 
-module.exports.update = function update({ id, title, description, isDeleted }) {
+module.exports.update = function update({ id, title, isDeleted }) {
   return Section.update(id, {
     title,
-    description,
     isDeleted
   })
     .then(head)

--- a/repositories/SectionRepository.test.js
+++ b/repositories/SectionRepository.test.js
@@ -17,7 +17,6 @@ const buildQuestionnaire = questionnaire => ({
 
 const buildSection = section => ({
   title: "Test section",
-  description: "section description",
   ...section
 });
 
@@ -63,8 +62,7 @@ describe("SectionRepository", () => {
 
     await SectionRepository.update({
       id: result.id,
-      title: "updated title",
-      description: "updated description"
+      title: "updated title"
     });
     const updated = await SectionRepository.getById(result.id);
 

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -35,7 +35,6 @@ const Resolvers = {
       );
       const section = {
         title: "",
-        description: "",
         questionnaireId: questionnaire.id
       };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,9 +1297,9 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-eq-author-graphql-schema@0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.19.0.tgz#2f262270682f1d5bbb88f82752579cb00bf3cc1f"
+eq-author-graphql-schema@0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.20.0.tgz#96ba25a2986e9931651ade66658a7cfe5670a054"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
### What is the context of this PR?
- Upgrades graphql schema which deprecates section description field as it is redundant and never used by eq-runner
- Stops adding section description content when creating a questionnaire
- Section description will remain in the DB schema and repository methods whilst the field is still supported

### How to review 
- Run tests
- Ensure sections can still be queried and mutated with / without section descriptions

### Dependancies
GraphQL Schema - https://github.com/ONSdigital/eq-author-graphql-schema/pull/51