### PR TITLE
Allow non-number answers to return null from validation resolver.

### DIFF
--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -287,7 +287,8 @@ const Resolvers = {
   BasicAnswer: {
     page: (answer, args, ctx) =>
       ctx.repositories.QuestionPage.getById(answer.questionPageId),
-    validation: answer => answer
+    validation: answer =>
+      getValidationEntity(answer.type) !== "number" ? null : answer
   },
 
   CompositeAnswer: {


### PR DESCRIPTION
### What is the context of this PR?
Returns null from the validation node in basic answers for all non-number answer types.

### How to review
Run tests
