### PR TITLE
Added new migration

### DIFF
--- a/migrations/20180822122408_add_min_max_validation_to_existing_number_currency_answers.js
+++ b/migrations/20180822122408_add_min_max_validation_to_existing_number_currency_answers.js
@@ -1,0 +1,29 @@
+exports.up = async function(knex) {
+  const ids = await knex
+    .select("Answers.id")
+    .from("Answers")
+    .where(function() {
+      this.where({ type: "Currency" }).orWhere({ type: "Number" });
+    })
+    .leftOuterJoin("Validation_AnswerRules", function() {
+      this.on("Validation_AnswerRules.AnswerId", "=", "Answers.id");
+    })
+    .whereNull("Validation_AnswerRules.id");
+
+  return ids.map(({ id }) => {
+    return ["minValue", "maxValue"].map(validationType => {
+      return knex("Validation_AnswerRules").insert({
+        AnswerId: id,
+        validationType,
+        config: { inclusive: false }
+      });
+    });
+  });
+};
+
+exports.down = async function() {
+  /*
+  This migration will not have a rollback mechanism as due to the addition of specific data 
+  it is not possible to re-identity that data to delete it in a rollback action.
+  */
+};


### PR DESCRIPTION
### What is the context of this PR?
The changes made to the api during the addition of min value validation were not backwards compatible as no data was being created for the existing answers.
This PR aims to add a mutation which can add empty data to all existing answers that now need those validation rows.  

### How to review 
Test on database, add number answer, delete the validations, then run this migration.

Test using a large amount of data, quickest way I found to create the data was to use this mutation on the graphql client.

mutation{
  createAnswer(input: {
    type: Currency
    questionPageId: 1
  }){
   id 
  }
}


Then execute the following code in the browser:

` var b = document.querySelector("[class='execute-button']")`
`for (var i =0 ; i<2000; i++){
    b.click()
}`


Finally delete everything in the validations database and run the mutation. 
