### PR TITLE
Migration to add validations to existing answers.

### DIFF
--- a/migrations/20180824093112_add_min_max_validation_to_existing_answers_v2.js
+++ b/migrations/20180824093112_add_min_max_validation_to_existing_answers_v2.js
@@ -1,0 +1,31 @@
+const { flatMap } = require("lodash");
+
+exports.up = async function(knex) {
+  await knex("Validation_AnswerRules").del();
+
+  const ids = await knex
+    .select("Answers.id")
+    .from("Answers")
+    .where(function() {
+      this.where({ type: "Currency" }).orWhere({ type: "Number" });
+    });
+
+  const result = flatMap(ids, ({ id }) => {
+    return ["minValue", "maxValue"].map(validationType => {
+      return knex("Validation_AnswerRules").insert({
+        AnswerId: id,
+        validationType,
+        config: { inclusive: false }
+      });
+    });
+  });
+
+  return Promise.all(result);
+};
+
+exports.down = async function() {
+  /*
+  This migration will not have a rollback mechanism as due to the addition of specific data 
+  it is not possible to re-identity that data to delete it in a rollback action.
+  */
+};


### PR DESCRIPTION
### What is the context of this PR?
This previous PR attempt to add min and max validations to existing answers did not work as expected. For some reason the data was never updated in the database. This may have been because of promises not resolving correctly and so this PR adds a new migration that should ensure that all promises are resolved before the migration ends. It will also wipe all data in the validations table so that a fresh state can be ensured preventing any entries from becoming invalid.

### How to review 
Same as https://github.com/ONSdigital/eq-author-api/pull/107
