### PR TITLE
548 metadata

### DIFF
--- a/db/Metadata.js
+++ b/db/Metadata.js
@@ -1,0 +1,35 @@
+const db = require("./");
+
+function Metadata() {
+  return db("Metadata");
+}
+
+module.exports.findAll = function findAll() {
+  return Metadata().select();
+};
+
+module.exports.findById = function findById(id) {
+  return Metadata()
+    .where("id", parseInt(id, 10))
+    .first();
+};
+
+module.exports.update = function update(id, updates) {
+  return Metadata()
+    .where("id", parseInt(id, 10))
+    .update(updates)
+    .returning("*");
+};
+
+module.exports.create = function create(obj) {
+  return Metadata()
+    .insert(obj)
+    .returning("*");
+};
+
+module.exports.destroy = function destroy(id) {
+  return Metadata()
+    .where("id", parseInt(id, 10))
+    .delete()
+    .returning("*");
+};

--- a/migrations/20180828155216_create_questionnaire_metadata_table.js
+++ b/migrations/20180828155216_create_questionnaire_metadata_table.js
@@ -1,0 +1,27 @@
+exports.up = function(knex) {
+  return knex.schema.createTable("Metadata", function(table) {
+    table.increments();
+    table.string("key");
+    table.string("alias");
+    table
+      .enum("type", ["Date", "Text", "Region", "Language"])
+      .notNullable()
+      .defaultTo("Text");
+    table.string("value");
+    table
+      .bool("isDeleted")
+      .notNull()
+      .defaultTo(false);
+    table
+      .integer("QuestionnaireId")
+      .unsigned()
+      .index()
+      .references("id")
+      .inTable("Questionnaires")
+      .onDelete("CASCADE");
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable("Metadata");
+};

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^6.0.0",
-    "eq-author-graphql-schema": "0.24.0",
+    "eq-author-graphql-schema": "^0.25.0",
     "express": "^4.15.3",
     "express-pino-logger": "^3.0.1",
     "graphql": "^0.13.2",

--- a/repositories/MetadataRepository.js
+++ b/repositories/MetadataRepository.js
@@ -1,0 +1,54 @@
+const { head, invert, map } = require("lodash/fp");
+
+const Metadata = require("../db/Metadata");
+const mapFields = require("../utils/mapFields");
+const mapping = { QuestionnaireId: "questionnaireId" };
+
+const fromDb = mapFields(mapping);
+const toDb = mapFields(invert(mapping));
+
+const TYPE_VALUE = {
+  Date: "dateValue",
+  Text: "textValue",
+  Region: "regionValue",
+  Language: "languageValue"
+};
+
+module.exports.getById = function(id) {
+  return Metadata.findById(id)
+    .where({ isDeleted: false })
+    .then(fromDb);
+};
+
+module.exports.findAll = function findAll(where = {}) {
+  return Metadata.findAll()
+    .where({ isDeleted: false })
+    .where(where)
+    .then(map(fromDb));
+};
+
+module.exports.insert = function({ questionnaireId }) {
+  return Metadata.create(toDb({ questionnaireId }))
+    .then(head)
+    .then(fromDb);
+};
+
+module.exports.update = function({ id, key, alias, type, ...values }) {
+  const typeField = TYPE_VALUE[type];
+
+  return Metadata.update(id, {
+    id,
+    key,
+    alias,
+    type,
+    value: values[typeField]
+  })
+    .then(head)
+    .then(fromDb);
+};
+
+module.exports.remove = function(id) {
+  return Metadata.update(id, { isDeleted: true })
+    .then(head)
+    .then(fromDb);
+};

--- a/repositories/MetadataRepository.test.js
+++ b/repositories/MetadataRepository.test.js
@@ -1,0 +1,169 @@
+const { map, times, omit } = require("lodash");
+
+const db = require("../db");
+const QuestionnaireRepository = require("../repositories/QuestionnaireRepository");
+const MetadataRepository = require("../repositories/MetadataRepository");
+
+const buildQuestionnaire = (json = {}) => {
+  return Object.assign(
+    {
+      title: "Test questionnaire",
+      surveyId: "1",
+      theme: "default",
+      legalBasis: "Voluntary",
+      navigation: false,
+      createdBy: "foo"
+    },
+    json
+  );
+};
+
+const buildMetadata = (questionnaireId, json = {}) => {
+  return Object.assign(
+    {
+      type: "Text",
+      questionnaireId: questionnaireId
+    },
+    json
+  );
+};
+
+describe("MetadataRepository", () => {
+  let questionnaireId;
+
+  beforeAll(() => db.migrate.latest());
+  afterAll(() => db.destroy());
+  afterEach(() => db("Questionnaires").delete());
+  beforeEach(async () => {
+    const questionnaire = buildQuestionnaire({ title: "New questionnaire" });
+    ({ id: questionnaireId } = await QuestionnaireRepository.insert(
+      questionnaire
+    ));
+  });
+
+  it("should retrieve a single Metadata", async () => {
+    const metadata = buildMetadata(questionnaireId);
+    const { id } = await MetadataRepository.insert(metadata);
+    const result = await MetadataRepository.getById(id);
+
+    expect(result.id).toBe(id);
+    expect(result).toMatchObject({
+      type: "Text",
+      questionnaireId
+    });
+  });
+
+  it("should retrieve all Metadata", async () => {
+    const metadata = times(4, async () => {
+      const metadata = buildMetadata(questionnaireId);
+      const { id } = await MetadataRepository.insert(metadata);
+      return id;
+    });
+    const metadataIds = await Promise.all(metadata);
+    const results = map(await MetadataRepository.findAll(), "id");
+    expect(results).toEqual(expect.arrayContaining(metadataIds));
+  });
+
+  it("should create new Metadata", async () => {
+    const metadata = buildMetadata(questionnaireId);
+    const result = await MetadataRepository.insert(metadata);
+    expect(result).toMatchObject({
+      type: "Text",
+      questionnaireId
+    });
+  });
+
+  it("should update Metadata - text", async () => {
+    const metadata = buildMetadata(questionnaireId);
+    const { id } = await MetadataRepository.insert(metadata);
+
+    const updateValues = {
+      id,
+      key: "ru_ref",
+      alias: "Reporting Unit Reference",
+      type: "Text",
+      textValue: "10000000",
+      questionnaireId: questionnaireId
+    };
+
+    const result = await MetadataRepository.update(updateValues);
+
+    expect(result).toMatchObject(
+      omit({ ...updateValues, value: "10000000" }, ["textValue"])
+    );
+  });
+
+  it("should update Metadata - date", async () => {
+    const metadata = buildMetadata(questionnaireId);
+    const { id } = await MetadataRepository.insert(metadata);
+
+    const updateValues = {
+      id,
+      key: "ru_ref",
+      alias: "Reporting Unit Reference",
+      type: "Date",
+      dateValue: new Date("2018-09-04"),
+      questionnaireId: questionnaireId
+    };
+
+    const result = await MetadataRepository.update(updateValues);
+
+    expect(result).toMatchObject(
+      omit(
+        {
+          ...updateValues,
+          value: expect.stringContaining("2018-09-04")
+        },
+        ["dateValue"]
+      )
+    );
+  });
+
+  it("should update Metadata - region", async () => {
+    const metadata = buildMetadata(questionnaireId);
+    const { id } = await MetadataRepository.insert(metadata);
+
+    const updateValues = {
+      id,
+      key: "ru_ref",
+      alias: "Reporting Unit Reference",
+      type: "Region",
+      regionValue: "GB_ENG",
+      questionnaireId: questionnaireId
+    };
+
+    const result = await MetadataRepository.update(updateValues);
+
+    expect(result).toMatchObject(
+      omit({ ...updateValues, value: "GB_ENG" }, ["regionValue"])
+    );
+  });
+
+  it("should update Metadata - language", async () => {
+    const metadata = buildMetadata(questionnaireId);
+    const { id } = await MetadataRepository.insert(metadata);
+
+    const updateValues = {
+      id,
+      key: "ru_ref",
+      alias: "Reporting Unit Reference",
+      type: "Language",
+      languageValue: "cy",
+      questionnaireId: questionnaireId
+    };
+
+    const result = await MetadataRepository.update(updateValues);
+
+    expect(result).toMatchObject(
+      omit({ ...updateValues, value: "cy" }, ["languageValue"])
+    );
+  });
+
+  it("should remove Metadata", async () => {
+    const metadata = buildMetadata(questionnaireId);
+    const { id } = await MetadataRepository.insert(metadata);
+    await MetadataRepository.remove(id);
+    const result = await MetadataRepository.getById(id);
+    expect(result).toBeUndefined();
+  });
+});

--- a/repositories/index.js
+++ b/repositories/index.js
@@ -6,5 +6,6 @@ module.exports = {
   Answer: require("./AnswerRepository"),
   Option: require("./OptionRepository"),
   Routing: require("./RoutingRepository"),
-  Validation: require("./ValidationRepository")
+  Validation: require("./ValidationRepository"),
+  Metadata: require("./MetadataRepository")
 };

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -148,21 +148,28 @@ const Resolvers = {
     toggleValidationRule: (_, args, ctx) =>
       ctx.repositories.Validation.toggleValidationRule(args.input),
     updateValidationRule: (_, args, ctx) =>
-      ctx.repositories.Validation.updateValidationRule(args.input)
+      ctx.repositories.Validation.updateValidationRule(args.input),
+    createMetadata: (root, args, ctx) =>
+      ctx.repositories.Metadata.insert(args.input),
+    updateMetadata: (_, args, ctx) =>
+      ctx.repositories.Metadata.update(args.input),
+    deleteMetadata: (_, args, ctx) =>
+      ctx.repositories.Metadata.remove(args.input.id)
   },
 
   Questionnaire: {
     sections: (questionnaire, args, ctx) =>
       ctx.repositories.Section.findAll({ QuestionnaireId: questionnaire.id }),
     createdBy: questionnaire => ({ name: questionnaire.createdBy }),
-    questionnaireInfo: ({ id }) => id
+    questionnaireInfo: ({ id }) => id,
+    metadata: (questionnaire, args, ctx) =>
+      ctx.repositories.Metadata.findAll({ QuestionnaireId: questionnaire.id })
   },
 
   QuestionnaireInfo: {
     totalSectionCount: (questionnaireId, args, ctx) =>
       ctx.repositories.Section.getSectionCount(questionnaireId)
   },
-
   Section: {
     pages: (section, args, ctx) =>
       ctx.repositories.Page.findAll({ SectionId: section.id }),
@@ -392,8 +399,16 @@ const Resolvers = {
     custom: ({ custom }) => custom
   },
 
+  Metadata: {
+    textValue: ({ type, value }) => (type === "Text" ? value : null),
+    languageValue: ({ type, value }) => (type === "Language" ? value : null),
+    regionValue: ({ type, value }) => (type === "Region" ? value : null),
+    dateValue: ({ type, value }) => (type === "Date" ? value : null)
+  },
+
   Date: GraphQLDate,
 
   JSON: GraphQLJSON
 };
+
 module.exports = Resolvers;

--- a/tests/schema/mutations/createMetadata.test.js
+++ b/tests/schema/mutations/createMetadata.test.js
@@ -1,0 +1,40 @@
+const executeQuery = require("../../utils/executeQuery");
+const mockRepository = require("../../utils/mockRepository");
+
+describe("createMetadata", () => {
+  const createMetadata = `
+    mutation CreateMetadata($input: CreateMetadataInput!) {
+      createMetadata(input: $input) {
+        id
+      }
+    }
+  `;
+
+  const METADATA_ID = "100";
+  const QUESTIONNAIRE_ID = "101";
+  let repositories;
+
+  beforeEach(() => {
+    repositories = {
+      Metadata: mockRepository({
+        insert: { id: METADATA_ID, questionnaireId: QUESTIONNAIRE_ID }
+      })
+    };
+  });
+
+  it("should allow creation of Metadata", async () => {
+    const input = {
+      questionnaireId: QUESTIONNAIRE_ID
+    };
+
+    const result = await executeQuery(
+      createMetadata,
+      { input },
+      { repositories }
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(repositories.Metadata.insert).toHaveBeenCalledWith(input);
+    expect(result.data.createMetadata.id).toBe(METADATA_ID);
+  });
+});

--- a/tests/schema/mutations/deleteMetadata.test.js
+++ b/tests/schema/mutations/deleteMetadata.test.js
@@ -1,0 +1,34 @@
+const executeQuery = require("../../utils/executeQuery");
+const mockRepository = require("../../utils/mockRepository");
+
+describe("deleteMetadata", () => {
+  const deleteMetadata = `
+    mutation DeleteMetadata($input: DeleteMetadataInput!) {
+      deleteMetadata(input: $input) {
+        id
+      }
+    }
+  `;
+
+  let repositories;
+
+  beforeEach(() => {
+    repositories = {
+      Metadata: mockRepository({
+        remove: { id: "1" }
+      })
+    };
+  });
+
+  it("should allow deletion of Metadata", async () => {
+    const input = { id: "1" };
+    const result = await executeQuery(
+      deleteMetadata,
+      { input },
+      { repositories }
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(repositories.Metadata.remove).toHaveBeenCalledWith(input.id);
+  });
+});

--- a/tests/schema/mutations/updateMetadata.test.js
+++ b/tests/schema/mutations/updateMetadata.test.js
@@ -1,0 +1,127 @@
+const executeQuery = require("../../utils/executeQuery");
+const mockRepository = require("../../utils/mockRepository");
+
+describe("updateMetadata", () => {
+  const updateMetadata = `
+    mutation UpdateMetadata($input: UpdateMetadataInput!) {
+      updateMetadata(input: $input) {
+        id
+      }
+    }
+  `;
+
+  const METADATA_ID = "100";
+  const basicInput = {
+    id: METADATA_ID,
+    key: "ru_ref",
+    alias: "Reporting Unit Reference"
+  };
+
+  let repositories;
+
+  beforeEach(() => {
+    repositories = {
+      Metadata: mockRepository({
+        update: {
+          id: METADATA_ID
+        }
+      })
+    };
+  });
+
+  it("should allow update of Metadata for textValue", async () => {
+    const input = {
+      ...basicInput,
+      type: "Text",
+      textValue: "test value"
+    };
+
+    const expected = {
+      ...basicInput,
+      type: "Text",
+      textValue: "test value"
+    };
+
+    const result = await executeQuery(
+      updateMetadata,
+      { input },
+      { repositories }
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(repositories.Metadata.update).toHaveBeenCalledWith(expected);
+    expect(result.data.updateMetadata.id).toBe(METADATA_ID);
+  });
+
+  it("should allow update of Metadata for regionValue", async () => {
+    const input = {
+      ...basicInput,
+      type: "Region",
+      regionValue: "GB_ENG"
+    };
+
+    const expected = {
+      ...basicInput,
+      type: "Region",
+      regionValue: "GB_ENG"
+    };
+
+    const result = await executeQuery(
+      updateMetadata,
+      { input },
+      { repositories }
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(repositories.Metadata.update).toHaveBeenCalledWith(expected);
+    expect(result.data.updateMetadata.id).toBe(METADATA_ID);
+  });
+
+  it("should allow update of Metadata for languageValue", async () => {
+    const input = {
+      ...basicInput,
+      type: "Language",
+      languageValue: "cy"
+    };
+
+    const expected = {
+      ...basicInput,
+      type: "Language",
+      languageValue: "cy"
+    };
+
+    const result = await executeQuery(
+      updateMetadata,
+      { input },
+      { repositories }
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(repositories.Metadata.update).toHaveBeenCalledWith(expected);
+    expect(result.data.updateMetadata.id).toBe(METADATA_ID);
+  });
+
+  it("should allow update of Metadata for dateValue", async () => {
+    const input = {
+      ...basicInput,
+      type: "Date",
+      dateValue: "2007-12-03"
+    };
+
+    const expected = {
+      ...basicInput,
+      type: "Date",
+      dateValue: new Date("2007-12-03")
+    };
+
+    const result = await executeQuery(
+      updateMetadata,
+      { input },
+      { repositories }
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(repositories.Metadata.update).toHaveBeenCalledWith(expected);
+    expect(result.data.updateMetadata.id).toBe(METADATA_ID);
+  });
+});

--- a/tests/schema/queries/metadata.test.js
+++ b/tests/schema/queries/metadata.test.js
@@ -1,0 +1,75 @@
+const executeQuery = require("../../utils/executeQuery");
+const mockRepository = require("../../utils/mockRepository");
+
+describe("Metadata query", () => {
+  const metadata = `
+   query GetQuestionnaireWithMetadata($questionnaireId: ID!) {
+      questionnaire(id: $questionnaireId) {
+        id
+        metadata {
+          id
+          type
+          textValue
+          languageValue
+          regionValue
+          dateValue
+        }
+      }
+    }
+  `;
+
+  const QUESTIONNAIRE_ID = "2";
+
+  let repositories;
+
+  beforeEach(() => {
+    repositories = {
+      Questionnaire: mockRepository({
+        getById: {
+          id: QUESTIONNAIRE_ID
+        }
+      }),
+      Metadata: mockRepository({
+        findAll: [
+          { id: 1, type: "Text", value: "hello" },
+          { id: 2, type: "Language", value: "en" },
+          { id: 3, type: "Region", value: "GB_ENG" },
+          { id: 4, type: "Date", value: "2018-01-01" }
+        ]
+      })
+    };
+  });
+
+  it("should fetch all metadata for a questionnaire", async () => {
+    const result = await executeQuery(
+      metadata,
+      { questionnaireId: QUESTIONNAIRE_ID },
+      { repositories }
+    );
+    expect(result.errors).toBeUndefined();
+    expect(repositories.Metadata.findAll).toHaveBeenCalledWith({
+      QuestionnaireId: QUESTIONNAIRE_ID
+    });
+    expect(result.data.questionnaire.metadata).toHaveLength(4);
+    expect(result.data.questionnaire.metadata[0]).toEqual(
+      expect.objectContaining({
+        textValue: "hello"
+      })
+    );
+    expect(result.data.questionnaire.metadata[1]).toEqual(
+      expect.objectContaining({
+        languageValue: "en"
+      })
+    );
+    expect(result.data.questionnaire.metadata[2]).toEqual(
+      expect.objectContaining({
+        regionValue: "GB_ENG"
+      })
+    );
+    expect(result.data.questionnaire.metadata[3]).toEqual(
+      expect.objectContaining({
+        dateValue: "2018-01-01"
+      })
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,9 +1297,9 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-eq-author-graphql-schema@0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.24.0.tgz#238d2ce167a9962cdf9eb7d73cd94f83a9ba7304"
+eq-author-graphql-schema@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.25.0.tgz#0125702e18c669d74f6bcd8d7462836ddcc27515"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
### What is the context of this PR?
Introduces `Metadata` to `Questionnaire`

### How to review 
- Run Tests
- Use eQ Author GraphQL API explorer to test mutations and queries eg.

```
mutation CreateMetadata($input: CreateMetadataInput!) {
  createMetadata(input: $input) {
    id
  }
}

#Query Variables
{
  "input": {
    "questionnaireId": "1"
  }
}
--

mutation UpdateMetadata($input: UpdateMetadataInput!) {
  updateMetadata(input: $input) {
    id
  }
}

#Query Variables
{
  "input": {
    "id": "1",
    "key": "ru_ref",
    "alias": "Reporting Unit Reference",
    "type": "Text",
    "textValue": "test"
  }
}
--

query GetQuestionnaireWithMetadata($questionnaireId: ID!) {
  questionnaire(id: $questionnaireId) {
    id
    metadata {
      id
      type
      textValue
      languageValue
      regionValue
      dateValue
    }
  }
}

#Query Variables
{
  "questionnaireId": 1
}
--

mutation DeleteMetadata($input: DeleteMetadataInput!) {
  deleteMetadata(input: $input) {
    id
  }
}

#Query Variables
{
  "input": {
    "id": "1"
  }
}
```

### Dependancies

https://github.com/ONSdigital/eq-author-graphql-schema/pull/58