### PR TITLE
561 create mutation for duplicating a page

### DIFF
--- a/repositories/OptionRepository.js
+++ b/repositories/OptionRepository.js
@@ -27,7 +27,7 @@ const checkForExistingExclusive = async answerId => {
   }
 };
 
-const findAll = (where = {}, orderBy = "created_at", direction = "asc") =>
+const findAll = (where = {}, orderBy = "id", direction = "asc") =>
   Option.findAll()
     .where({ isDeleted: false, otherAnswerId: null })
     .where(where)

--- a/repositories/QuestionnaireRepository.test.js
+++ b/repositories/QuestionnaireRepository.test.js
@@ -17,7 +17,7 @@ const buildQuestionnaire = (json = {}) => {
 
 describe("QuestionnaireRepository", () => {
   beforeAll(() => knex.migrate.latest());
-  afterAll(() => knex.migrate.rollback().then(() => knex.destroy()));
+  afterAll(() => knex.destroy());
   afterEach(() => knex("Questionnaires").delete());
 
   it("should create new Questionnaire", async () => {

--- a/repositories/SectionRepository.test.js
+++ b/repositories/SectionRepository.test.js
@@ -36,7 +36,7 @@ const eachP = (items, iter) =>
 
 describe("SectionRepository", () => {
   beforeAll(() => db.migrate.latest());
-  afterAll(() => db.migrate.rollback().then(() => db.destroy()));
+  afterAll(() => db.destroy());
   afterEach(() => db("Questionnaires").delete());
 
   it("allows sections to be created", async () => {

--- a/repositories/strategies/duplicateStrategy.js
+++ b/repositories/strategies/duplicateStrategy.js
@@ -1,0 +1,214 @@
+const { omit, head, get, isNil } = require("lodash");
+const { getOrUpdateOrderForPageInsert } = require("./spacedOrderStrategy");
+
+const insertData = async (
+  trx,
+  tableName,
+  data,
+  callback,
+  returning = "*",
+  position
+) => {
+  const returnedData = await trx
+    .table(tableName)
+    .insert(data)
+    .returning(returning)
+    .then(callback);
+
+  if (returnedData.order) {
+    const order = await getOrUpdateOrderForPageInsert(
+      trx,
+      returnedData.SectionId,
+      returnedData.id,
+      position
+    );
+
+    await trx
+      .table(tableName)
+      .update({ order })
+      .where({ id: returnedData.id });
+  }
+
+  return returnedData;
+};
+
+const selectData = (trx, tableName, columns, where, orderBy) => {
+  const queryP = trx
+    .select(columns)
+    .from(tableName)
+    .where(where);
+  if (orderBy) {
+    const { column, direction } = orderBy;
+    queryP.orderBy(column, direction);
+  }
+  return queryP;
+};
+
+const duplicateRecord = async (
+  trx,
+  tableName,
+  record,
+  overrides = {},
+  position
+) => {
+  const duplicatedRecord = omit(record, "id", "created_at", "updated_at");
+  const { parentRelation, ...other } = overrides;
+
+  if (!isNil(parentRelation)) {
+    duplicatedRecord[get(parentRelation, "columnName")] = get(
+      parentRelation,
+      "id"
+    );
+  }
+
+  const newRecord = { ...duplicatedRecord, ...other };
+
+  return insertData(trx, tableName, newRecord, head, "*", position);
+};
+
+const duplicateOptionStrategy = async (trx, option, overrides = {}) => {
+  const duplicatedOption = await duplicateRecord(
+    trx,
+    "Options",
+    option,
+    overrides
+  );
+
+  return selectData(trx, "Options", "*", { id: duplicatedOption.id }).then(
+    head
+  );
+};
+
+const duplicateValidationStrategy = async (trx, validation, overrides = {}) => {
+  const duplicatedValidation = await duplicateRecord(
+    trx,
+    "Validation_AnswerRules",
+    validation,
+    overrides
+  );
+
+  return selectData(trx, "Validation_AnswerRules", "*", {
+    id: duplicatedValidation.id
+  }).then(head);
+};
+
+const duplicateOtherAnswer = async (trx, otherAnswer, duplicateAnswer) => {
+  const duplicateOtherAnswer = omit(otherAnswer, "id");
+  duplicateOtherAnswer.parentAnswerId = duplicateAnswer.id;
+
+  const duplicateOtherAnswerId = await insertData(
+    trx,
+    "Answers",
+    duplicateOtherAnswer,
+    head,
+    "id"
+  );
+
+  const otherOptionToDuplicate = await selectData(trx, "Options", "*", {
+    otherAnswerId: otherAnswer.id
+  }).then(head);
+
+  await duplicateOptionStrategy(trx, otherOptionToDuplicate, {
+    parentRelation: { id: duplicateAnswer.id, columnName: "AnswerId" },
+    otherAnswerId: duplicateOtherAnswerId
+  });
+};
+
+const duplicateAnswerStrategy = async (trx, answer, overrides = {}) => {
+  const duplicateAnswer = await duplicateRecord(
+    trx,
+    "Answers",
+    answer,
+    overrides
+  );
+  const otherAnswer = await selectData(trx, "Answers", "*", {
+    parentAnswerId: answer.id
+  }).then(head);
+
+  if (otherAnswer) {
+    await duplicateOtherAnswer(trx, otherAnswer, duplicateAnswer);
+  }
+
+  const optionsToDuplicate = await selectData(
+    trx,
+    "Options",
+    "*",
+    {
+      AnswerId: answer.id,
+      otherAnswerId: null,
+      isDeleted: false
+    },
+    {
+      column: "id",
+      direction: "asc"
+    }
+  );
+
+  // Need to preserve id order so insert them in the order we got them
+  const promiseInsertionQueue = optionsToDuplicate.reduce(
+    (queue, option) =>
+      queue.then(() =>
+        duplicateOptionStrategy(trx, option, {
+          parentRelation: { id: duplicateAnswer.id, columnName: "AnswerId" }
+        })
+      ),
+    Promise.resolve()
+  );
+
+  await promiseInsertionQueue;
+
+  const validationsToDuplicate = await selectData(
+    trx,
+    "Validation_AnswerRules",
+    "*",
+    {
+      AnswerId: answer.id
+    }
+  );
+  await Promise.all(
+    validationsToDuplicate.map(validation =>
+      duplicateValidationStrategy(trx, validation, {
+        parentRelation: { id: duplicateAnswer.id, columnName: "AnswerId" }
+      })
+    )
+  );
+
+  return selectData(trx, "Answers", "*", { id: duplicateAnswer.id }).then(head);
+};
+
+const duplicatePageStrategy = async (trx, page, position, overrides = {}) => {
+  const duplicatePage = await duplicateRecord(
+    trx,
+    "Pages",
+    page,
+    overrides,
+    position
+  );
+
+  const answersToDuplicate = await selectData(trx, "Answers", "*", {
+    QuestionPageId: page.id,
+    isDeleted: false
+  });
+
+  await Promise.all(
+    answersToDuplicate.map(answer =>
+      duplicateAnswerStrategy(trx, answer, {
+        parentRelation: {
+          id: duplicatePage.id,
+          columnName: "QuestionPageId"
+        }
+      })
+    )
+  );
+
+  return selectData(trx, "Pages", "*", { id: duplicatePage.id }).then(head);
+};
+
+Object.assign(module.exports, {
+  insertData,
+  selectData,
+  duplicateRecord,
+  duplicateOptionStrategy,
+  duplicateAnswerStrategy,
+  duplicatePageStrategy
+});

--- a/repositories/strategies/duplicateStrategy.test.js
+++ b/repositories/strategies/duplicateStrategy.test.js
@@ -1,0 +1,449 @@
+const db = require("../../db");
+const { head, omit } = require("lodash");
+const {
+  insertData,
+  selectData,
+  duplicateRecord,
+  duplicateOptionStrategy,
+  duplicateAnswerStrategy,
+  duplicatePageStrategy
+} = require("./duplicateStrategy");
+const QuestionnaireRepository = require("../QuestionnaireRepository");
+const SectionRepository = require("../SectionRepository");
+const PageRepository = require("../PageRepository");
+
+const buildQuestionnaire = questionnaire => ({
+  title: "Test questionnaire",
+  surveyId: "1",
+  theme: "default",
+  legalBasis: "Voluntary",
+  navigation: false,
+  createdBy: "foo",
+  ...questionnaire
+});
+
+const buildSection = section => ({
+  title: "Test section",
+  description: "section description",
+  ...section
+});
+
+const buildPage = page => ({
+  title: "Test page",
+  description: "page description",
+  guidance: "page description",
+  pageType: "QuestionPage",
+  ...page
+});
+
+const buildOption = option => ({
+  label: "Test label",
+  description: "Option description",
+  ...option
+});
+
+const buildAnswer = answer => ({
+  label: "Test label",
+  description: "Answer description",
+  guidance: "Answer guidance",
+  type: "Radio",
+  ...answer
+});
+
+const buildValidation = validation => ({
+  validationType: "minValue",
+  enabled: false,
+  config: '{"inclusive": false}',
+  ...validation
+});
+
+const setup = async () => {
+  const questionnaire = await QuestionnaireRepository.insert(
+    buildQuestionnaire()
+  );
+
+  const section = await SectionRepository.insert(
+    buildSection({
+      questionnaireId: questionnaire.id
+    })
+  );
+
+  const page = await PageRepository.insert(
+    buildPage({
+      sectionId: section.id
+    })
+  );
+
+  return { questionnaire, section, page };
+};
+
+describe("Duplicate strategy tests", () => {
+  beforeAll(() => db.migrate.latest());
+  afterAll(() => db.destroy());
+  afterEach(() =>
+    Promise.all([
+      db("Questionnaires").delete(),
+      db("Answers").delete(),
+      db("Options").delete()
+    ]));
+
+  it("will insert data into the db correctly, given some data", async () => {
+    const { section } = await setup();
+
+    const dataToInsert = await buildPage({ SectionId: section.id });
+
+    const dataReturnedFromInsert = await db.transaction(trx => {
+      return insertData(trx, "Pages", dataToInsert, head, "*");
+    });
+
+    const dataReturnedFromSelect = await db
+      .select("*")
+      .from("Pages")
+      .where({ id: dataReturnedFromInsert.id })
+      .then(head);
+
+    expect({
+      ...dataReturnedFromInsert,
+      ...dataToInsert
+    }).toMatchObject(dataReturnedFromSelect);
+  });
+
+  it("will select data from the db correctly, given some previously inserted data", async () => {
+    const { section } = await setup();
+
+    const dataToInsert = buildPage({ SectionId: section.id });
+
+    const dataReturnedFromInsert = await db.transaction(trx => {
+      return insertData(trx, "Pages", dataToInsert, head, "*");
+    });
+
+    const dataReturnedFromSelect = await db.transaction(trx => {
+      return selectData(trx, "Pages", "*", {
+        id: dataReturnedFromInsert.id
+      }).then(head);
+    });
+
+    expect(dataReturnedFromSelect).toMatchObject({
+      ...dataReturnedFromInsert,
+      ...dataToInsert
+    });
+  });
+
+  it("will duplicate a record", async () => {
+    const fieldsToOmit = ["id", "created_at", "updated_at"];
+    const { section } = await setup();
+
+    const dataToInsert = buildPage({ SectionId: section.id });
+
+    const dataReturnedFromInsert = await db.transaction(trx => {
+      return insertData(trx, "Pages", dataToInsert, head, "*");
+    });
+
+    const duplicatedRecord = await db.transaction(trx => {
+      return duplicateRecord(
+        trx,
+        "Pages",
+        omit(dataReturnedFromInsert, fieldsToOmit)
+      );
+    });
+
+    expect(omit(dataReturnedFromInsert, fieldsToOmit)).toMatchObject(
+      omit(duplicatedRecord, fieldsToOmit)
+    );
+  });
+
+  it("will duplicate an option", async () => {
+    const fieldsToOmit = ["id", "created_at", "updated_at"];
+
+    const originalOption = await db.transaction(trx => {
+      return insertData(trx, "Options", buildOption(), head, "*");
+    });
+
+    const duplicateOption = await db.transaction(trx => {
+      return duplicateOptionStrategy(trx, omit(originalOption, fieldsToOmit));
+    });
+
+    expect(omit(duplicateOption, fieldsToOmit)).toMatchObject(
+      omit(originalOption, fieldsToOmit)
+    );
+  });
+
+  it("will duplicate an answer", async () => {
+    const fieldsToOmit = ["created_at", "updated_at"];
+
+    const originalAnswer = await db.transaction(trx => {
+      return insertData(trx, "Answers", buildAnswer(), head, "*");
+    });
+
+    const duplicateAnswer = await db.transaction(trx => {
+      return duplicateAnswerStrategy(trx, omit(originalAnswer, fieldsToOmit));
+    });
+
+    const fieldsToOmitIncludingId = [...fieldsToOmit, "id"];
+    expect(omit(duplicateAnswer, fieldsToOmitIncludingId)).toMatchObject(
+      omit(originalAnswer, fieldsToOmitIncludingId)
+    );
+  });
+
+  it("will duplicate an answer with an option", async () => {
+    const { page } = await setup();
+    const { answer, option } = await db.transaction(async trx => {
+      const answer = await insertData(
+        trx,
+        "Answers",
+        buildAnswer({ QuestionPageId: page.id }),
+        head,
+        "*"
+      );
+      const option = await insertData(
+        trx,
+        "Options",
+        buildOption({
+          AnswerId: answer.id
+        }),
+        head,
+        "*"
+      );
+      return { answer, option };
+    });
+
+    const duplicateOption = await db.transaction(async trx => {
+      const duplicateAnswer = await duplicateAnswerStrategy(trx, answer);
+      return selectData(trx, "Options", "*", {
+        AnswerId: duplicateAnswer.id
+      }).then(head);
+    });
+    const fieldsToIgnore = ["id", "created_at", "updated_at"];
+    expect(omit(fieldsToIgnore, duplicateOption)).toMatchObject(
+      omit(fieldsToIgnore, option)
+    );
+  });
+
+  const insertOption = (trx, answer, label) =>
+    insertData(
+      trx,
+      "Options",
+      buildOption({
+        AnswerId: answer.id,
+        label
+      }),
+      head,
+      "*"
+    );
+
+  it("will ensure the option order is maintained", async () => {
+    const { page } = await setup();
+    const { answer } = await db.transaction(async trx => {
+      const answer = await insertData(
+        trx,
+        "Answers",
+        buildAnswer({ QuestionPageId: page.id }),
+        head,
+        "*"
+      );
+
+      await insertOption(trx, answer, "1");
+      await insertOption(trx, answer, "2");
+      await insertOption(trx, answer, "3");
+      await insertOption(trx, answer, "4");
+
+      return { answer };
+    });
+
+    const duplicateOptions = await db.transaction(async trx => {
+      const duplicateAnswer = await duplicateAnswerStrategy(trx, answer);
+      return selectData(
+        trx,
+        "Options",
+        "*",
+        {
+          AnswerId: duplicateAnswer.id
+        },
+        {
+          column: "id",
+          direction: "asc"
+        }
+      );
+    });
+    expect(duplicateOptions.map(o => o.label)).toMatchObject([
+      "1",
+      "2",
+      "3",
+      "4"
+    ]);
+  });
+
+  it("will duplicate an answer with an other option", async () => {
+    const fieldsToOmit = ["created_at", "updated_at"];
+    const originalAnswer = await db.transaction(trx => {
+      return insertData(trx, "Answers", buildAnswer(), head, "*");
+    });
+    const originalOtherAnswer = await db.transaction(trx => {
+      return insertData(
+        trx,
+        "Answers",
+        buildAnswer({
+          type: "TextField",
+          parentAnswerId: originalAnswer.id
+        }),
+        head,
+        "*"
+      );
+    });
+    const originalOption = await db.transaction(trx => {
+      return insertData(
+        trx,
+        "Options",
+        buildOption({
+          AnswerId: originalAnswer.id,
+          otherAnswerId: originalOtherAnswer.id
+        }),
+        head,
+        "*"
+      );
+    });
+
+    const duplicateAnswer = await db.transaction(trx => {
+      return duplicateAnswerStrategy(trx, omit(originalAnswer, fieldsToOmit));
+    });
+    const { duplicateOption, duplicateOtherAnswer } = await db.transaction(
+      async trx => {
+        const duplicateOtherAnswer = await selectData(trx, "Answers", "*", {
+          parentAnswerId: duplicateAnswer.id
+        }).then(head);
+        const duplicateOption = await selectData(trx, "Options", "*", {
+          AnswerId: duplicateAnswer.id,
+          otherAnswerId: duplicateOtherAnswer.id
+        }).then(head);
+        return { duplicateOtherAnswer, duplicateOption };
+      }
+    );
+
+    const fieldsToOmitIncludingId = [...fieldsToOmit, "id"];
+    expect(omit(duplicateAnswer, fieldsToOmitIncludingId)).toMatchObject(
+      omit(originalAnswer, fieldsToOmitIncludingId)
+    );
+    expect(
+      omit(duplicateOption, [
+        ...fieldsToOmitIncludingId,
+        "AnswerId",
+        "otherAnswerId"
+      ])
+    ).toMatchObject(
+      omit(originalOption, [
+        ...fieldsToOmitIncludingId,
+        "AnswerId",
+        "otherAnswerId"
+      ])
+    );
+    expect(
+      omit(duplicateOtherAnswer, [...fieldsToOmitIncludingId, "parentAnswerId"])
+    ).toMatchObject(
+      omit(originalOtherAnswer, [...fieldsToOmitIncludingId, "parentAnswerId"])
+    );
+  });
+
+  it("will duplicate a page", async () => {
+    const notDuplicatedFields = ["created_at", "updated_at"];
+    const { section } = await setup();
+    const originalPage = await db.transaction(trx =>
+      insertData(trx, "Pages", buildPage({ SectionId: section.id }), head, "*")
+    );
+    const duplicatePage = await db.transaction(trx =>
+      duplicatePageStrategy(trx, omit(originalPage, notDuplicatedFields))
+    );
+    expect(omit(duplicatePage, [...notDuplicatedFields, "id"])).toMatchObject(
+      omit(originalPage, [...notDuplicatedFields, "id"])
+    );
+  });
+
+  it("will duplicate the answers on the page but not deleted ones", async () => {
+    const notDuplicatedFields = ["created_at", "updated_at"];
+    const { section } = await setup();
+    const { originalPage, originalAnswer } = await db.transaction(async trx => {
+      const originalPage = await insertData(
+        trx,
+        "Pages",
+        buildPage({ SectionId: section.id }),
+        head,
+        "*"
+      );
+      const originalAnswer = await insertData(
+        trx,
+        "Answers",
+        buildAnswer({ QuestionPageId: originalPage.id }),
+        head,
+        "*"
+      );
+      await insertData(
+        trx,
+        "Answers",
+        buildAnswer({ QuestionPageId: originalPage.id, isDeleted: true }),
+        head,
+        "*"
+      );
+      return { originalPage, originalAnswer };
+    });
+    const duplicatePage = await db.transaction(trx =>
+      duplicatePageStrategy(trx, omit(originalPage, notDuplicatedFields))
+    );
+
+    const duplicateAnswers = await db.transaction(trx =>
+      selectData(trx, "Answers", "*", {
+        QuestionPageId: duplicatePage.id
+      })
+    );
+    expect(duplicateAnswers).toHaveLength(1);
+    const firstAnswer = head(duplicateAnswers);
+    expect(
+      omit(firstAnswer, [...notDuplicatedFields, "id", "QuestionPageId"])
+    ).toMatchObject(
+      omit(originalAnswer, [...notDuplicatedFields, "id", "QuestionPageId"])
+    );
+  });
+
+  it("will duplicate the validations for an answer", async () => {
+    const { section } = await setup();
+    const { duplicatedAnswer, originalValidation } = await db.transaction(
+      async trx => {
+        const originalPage = await insertData(
+          trx,
+          "Pages",
+          buildPage({ SectionId: section.id }),
+          head,
+          "*"
+        );
+        const originalAnswer = await insertData(
+          trx,
+          "Answers",
+          buildAnswer({ QuestionPageId: originalPage.id }),
+          head,
+          "*"
+        );
+        const originalValidation = await insertData(
+          trx,
+          "Validation_AnswerRules",
+          buildValidation({ AnswerId: originalAnswer.id }),
+          head,
+          "*"
+        );
+        const duplicatedAnswer = await duplicateAnswerStrategy(
+          trx,
+          originalAnswer
+        );
+        return { duplicatedAnswer, originalValidation };
+      }
+    );
+
+    const duplicatedValidation = await db.transaction(trx =>
+      selectData(trx, "Validation_AnswerRules", "*", {
+        AnswerId: duplicatedAnswer.id
+      }).then(head)
+    );
+    const fieldsToIgnore = ["id", "created_at", "updated_at", "AnswerId"];
+
+    expect(omit(duplicatedValidation, fieldsToIgnore)).toMatchObject(
+      omit(originalValidation, fieldsToIgnore)
+    );
+  });
+});

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -49,6 +49,9 @@ const Resolvers = {
       ctx.repositories.Questionnaire.remove(args.input.id),
     undeleteQuestionnaire: (_, args, ctx) =>
       ctx.repositories.Questionnaire.undelete(args.input.id),
+    duplicateQuestionnaire: () => {
+      throw new Error("Not implemented");
+    },
 
     createSection: async (root, args, ctx) => {
       const section = await ctx.repositories.Section.insert(args.input);
@@ -69,6 +72,9 @@ const Resolvers = {
     undeleteSection: (_, args, ctx) =>
       ctx.repositories.Section.undelete(args.input.id),
     moveSection: (_, args, ctx) => ctx.repositories.Section.move(args.input),
+    duplicateSection: () => {
+      throw new Error("Not implemented");
+    },
 
     createPage: (root, args, ctx) => ctx.repositories.Page.insert(args.input),
 
@@ -77,6 +83,8 @@ const Resolvers = {
     undeletePage: (_, args, ctx) =>
       ctx.repositories.Page.undelete(args.input.id),
     movePage: (_, args, ctx) => ctx.repositories.Page.move(args.input),
+    duplicatePage: (_, args, ctx) =>
+      ctx.repositories.Page.duplicatePage(args.input.id, args.input.position),
 
     createQuestionPage: (root, args, ctx) =>
       ctx.repositories.Page.insert(

--- a/schema/resolvers.test.js
+++ b/schema/resolvers.test.js
@@ -329,7 +329,7 @@ describe("resolvers", () => {
   let firstPage;
 
   beforeAll(() => db.migrate.latest());
-  afterAll(() => db.migrate.rollback().then(() => db.destroy()));
+  afterAll(() => db.destroy());
   afterEach(() => db("Questionnaires").delete());
 
   beforeEach(async () => {

--- a/schema/resolversTests/properties.test.js
+++ b/schema/resolversTests/properties.test.js
@@ -75,7 +75,7 @@ describe("resolvers", () => {
   let firstPage;
 
   beforeAll(() => db.migrate.latest());
-  afterAll(() => db.migrate.rollback().then(() => db.destroy()));
+  afterAll(() => db.destroy());
   afterEach(() => db("Questionnaires").delete());
 
   beforeEach(async () => {

--- a/schema/resolversTests/validation.test.js
+++ b/schema/resolversTests/validation.test.js
@@ -87,7 +87,7 @@ describe("resolvers", () => {
   let firstPage;
 
   beforeAll(() => db.migrate.latest());
-  afterAll(() => db.migrate.rollback().then(() => db.destroy()));
+  afterAll(() => db.destroy());
   afterEach(() => db("Questionnaires").delete());
 
   beforeEach(async () => {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -25,4 +25,4 @@ echo "waiting on postgres to start..."
 
 echo "running tests..."
 
-NODE_ENV=test DB_CONNECTION_URI="postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST/postgres" yarn jest --runInBand $1
+NODE_ENV=test DB_CONNECTION_URI="postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST/postgres" yarn jest --runInBand "$@"

--- a/utils/updateTitle.js
+++ b/utils/updateTitle.js
@@ -1,0 +1,15 @@
+const { replace, isEmpty, isNil } = require("lodash");
+
+const fn = group => (isNil(group) ? "" : group);
+
+module.exports = (title, prefix = "Copy of ") => {
+  if (isNil(title) || isEmpty(title)) {
+    return "";
+  }
+
+  return replace(title, /(<\w+>)?([^<]*)(<\/\w+>)?/, (_, a, b, c) => {
+    return isEmpty(b)
+      ? `${fn(a)}${b}${fn(c)}`
+      : `${fn(a)}${prefix}${b}${fn(c)}`;
+  });
+};

--- a/utils/updateTitle.test.js
+++ b/utils/updateTitle.test.js
@@ -1,0 +1,65 @@
+const updateTitle = require("./updateTitle");
+
+describe("Update Title", () => {
+  it("should prepend 'Copy of' to a title without markup tags when no prefix is supplied", () => {
+    const title = "Hello";
+
+    const updatedTitle = updateTitle(title);
+
+    expect(updatedTitle).toBe(`Copy of ${title}`);
+  });
+
+  it("should prepend 'Copy of' to a title with markup tags when no prefix is supplied", () => {
+    const title = "<p>Hello</p>";
+
+    const updatedTitle = updateTitle(title);
+
+    const startsWithCopyOf = updatedTitle.startsWith("Copy of ", 3);
+
+    expect(startsWithCopyOf).toBe(true);
+  });
+
+  it("should not prepend 'Copy of' to a title without markup tags when a prefix is supplied", () => {
+    const title = "Hello";
+
+    const updatedTitle = updateTitle(title, "Oh,");
+
+    expect(updatedTitle).not.toBe(`Copy of ${title}`);
+  });
+
+  it("should not prepend 'Copy of' to a title with markup tags when a prefix is supplied", () => {
+    const title = "<p>Hello</p>";
+
+    const updatedTitle = updateTitle(title, "Oh,");
+
+    const startsWithCopyOf = updatedTitle.startsWith("Copy of ", 3);
+
+    expect(startsWithCopyOf).toBe(false);
+  });
+
+  it("should prepend a title without markup tags with a given prefix", () => {
+    const title = "Hello";
+
+    const updatedTitle = updateTitle(title, "Oh, ");
+
+    expect(updatedTitle).toBe(`Oh, ${title}`);
+  });
+
+  it("should prepend a title with markup tags with a given prefix", () => {
+    const title = "<p>Hello</p>";
+
+    const updatedTitle = updateTitle(title, "Oh, ");
+
+    const startsWithCopyOf = updatedTitle.startsWith("Oh, ", 3);
+
+    expect(startsWithCopyOf).toBe(true);
+  });
+
+  it("should not prepend an empty title", () => {
+    expect(updateTitle("")).toEqual("");
+  });
+
+  it("should not prepend an empty title surrounded by tags", () => {
+    expect(updateTitle("<p></p>")).toEqual("<p></p>");
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?
This PR adds the functionality in order to duplicate a page. 

>It also includes code for duplicating a section and questionnaire; these functions will not work just yet because some implementation for duplicating a page breaks these. This should be fixed in separate PRs because the additional functionality is not in scope for this ticket.

### How to review 
All tests should pass, and the code should work when calling the mutations included in [this schema PR](https://github.com/ONSdigital/eq-author-graphql-schema/pull/57)
