### PR TITLE
Fixed bug preventing move pages/sections from working

### DIFF
--- a/repositories/PageRepository.test.js
+++ b/repositories/PageRepository.test.js
@@ -139,7 +139,7 @@ describe("PagesRepository", () => {
       });
     });
 
-    it("can move pages within same section", async () => {
+    it("can move pages backwards within same section", async () => {
       const { section } = await setup();
       const pages = await createPages(section.id, 5);
 
@@ -157,6 +157,44 @@ describe("PagesRepository", () => {
       });
 
       expect(map(updatePages, "id")).toEqual(map(reverse(pages), "id"));
+    });
+
+    it("can move pages to the end of the current section", async () => {
+      const { section } = await setup();
+      const pages = await createPages(section.id, 5);
+
+      const middlePage = pages[3];
+
+      await PageRepository.move({
+        id: middlePage.id,
+        sectionId: section.id,
+        position: "5"
+      });
+
+      const updatePages = await PageRepository.findAll({
+        sectionId: section.id
+      });
+
+      expect(last(updatePages).id).toEqual(middlePage.id);
+    });
+
+    it("can move pages forwards in the current section", async () => {
+      const { section } = await setup();
+      const pages = await createPages(section.id, 5);
+
+      const firstPage = pages[0];
+
+      await PageRepository.move({
+        id: firstPage.id,
+        sectionId: section.id,
+        position: "3"
+      });
+
+      const updatePages = await PageRepository.findAll({
+        sectionId: section.id
+      });
+
+      expect(updatePages[3].id).toEqual(firstPage.id);
     });
 
     it("gracefully handles position values greater than number of pages", async () => {

--- a/repositories/SectionRepository.test.js
+++ b/repositories/SectionRepository.test.js
@@ -172,6 +172,28 @@ describe("SectionRepository", () => {
       expect(map(updatedSections, "id")).toEqual(map(reverse(sections), "id"));
     });
 
+    it("can move sections forwards", async () => {
+      const {
+        questionnaire: { id: questionnaireId }
+      } = await setup();
+
+      const sections = await createSections(questionnaireId, 5);
+
+      const firstSection = sections[0];
+
+      await SectionRepository.move({
+        id: firstSection.id,
+        questionnaireId: questionnaireId,
+        position: "3"
+      });
+
+      const updatedSections = await SectionRepository.findAll({
+        questionnaireId
+      });
+
+      expect(updatedSections[3].id).toEqual(firstSection.id);
+    });
+
     it("gracefully handles position values greater than number of pages", async () => {
       const {
         questionnaire: { id: questionnaireId }

--- a/repositories/strategies/spacedOrderStrategy.js
+++ b/repositories/strategies/spacedOrderStrategy.js
@@ -60,8 +60,10 @@ const getOrUpdateOrderForInsert = async (
     return maxOrder;
   }
 
+  collection.splice(position, 0, { id: "dummyElement" });
+
   let left = getOr(0, "order", collection[position - 1]);
-  let right = getOr(maxOrder, "order", collection[position]);
+  let right = getOr(maxOrder, "order", collection[position + 1]);
 
   if (valuesHaveConverged(left, right)) {
     await makeSpaceForInsert(trx, type, parentId, left);
@@ -71,8 +73,16 @@ const getOrUpdateOrderForInsert = async (
   return calculateMidPoint(left, right);
 };
 
-const getOrUpdateOrderForPageInsert = async (trx, sectionId, id, position) => {
-  const pages = reject({ id }, await getPagesBySection(trx, sectionId));
+const getOrUpdateOrderForPageInsert = async (
+  trx,
+  sectionId,
+  movingPageId,
+  position
+) => {
+  const pages = reject(
+    { id: parseInt(movingPageId, 10) },
+    await getPagesBySection(trx, sectionId)
+  );
 
   return getOrUpdateOrderForInsert(trx, pages, "Pages", sectionId, position);
 };

--- a/repositories/strategies/spacedOrderStrategy.js
+++ b/repositories/strategies/spacedOrderStrategy.js
@@ -94,7 +94,7 @@ const getOrUpdateOrderForSectionInsert = async (
   position
 ) => {
   const sections = reject(
-    { id },
+    { id: parseInt(id, 10) },
     await getSectionsByQuestionnaire(trx, questionnaireId)
   );
 


### PR DESCRIPTION
### What is the context of this PR?
There is currently a bug on the move page api where trying to move a page forward creates unpredictable results this PR aims to bring the move page feature back into a working state.

### How to review 
New test passes and the move page feature works.
