### PR TITLE
Fix graphql-iso-date package incapability of resolving ISO datetime s…

### DIFF
--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -411,7 +411,12 @@ const Resolvers = {
     textValue: ({ type, value }) => (type === "Text" ? value : null),
     languageValue: ({ type, value }) => (type === "Language" ? value : null),
     regionValue: ({ type, value }) => (type === "Region" ? value : null),
-    dateValue: ({ type, value }) => (type === "Date" ? value : null)
+    dateValue: ({ type, value }) => {
+      if (type !== "Date" || !value) {
+        return null;
+      }
+      return new Date(value);
+    }
   },
 
   Date: GraphQLDate,


### PR DESCRIPTION
### What is the context of this PR?
Fixes `graphql-iso-date` package incapability of resolving ISO DateTime strings for Date types. Currently `graphql-iso-date` converts date strings `2018-01-01` to ISO DateTime strings on write, however, on read it cannot convert ISO DateTime strings to a valid format and the below error is thrown:

`Date cannot represent an invalid date-string 2018-01-01T00:00:00.000+00:00`

### Describe the steps required to test the changes (include screenshots if appropriate).

- Add a metadata with a valid`dateValue` eg. `2018-01-01`
- Query metadata and ensure `dateValue` is returned 

```
mutation UpdateMetadata($input: UpdateMetadataInput!) {
  updateMetadata(input: $input) {
    id
  }
}

#Query Variables
{
  "input": {
    "id": "1",
    "type": "Date",
    "dateValue": "2018-01-01"
  }
}

query GetQuestionnaireWithMetadata($questionnaireId: ID!) {
      questionnaire(id: $questionnaireId) {
        id
        metadata {
          id
          key
          alias
          type
          textValue
          languageValue
          regionValue
          dateValue
        }
      }
    }

#Query Variables
{
  "questionnaireId": 1
}
```