### PR TITLE
449 - Earliest date validation

### DIFF
--- a/migrations/20180907155542_add_earliest_date_validation.js
+++ b/migrations/20180907155542_add_earliest_date_validation.js
@@ -27,7 +27,6 @@ exports.up = async function(knex) {
       AnswerId: id,
       validationType: "earliestDate",
       config: {
-        inclusive: false,
         offset: {
           value: 0,
           unit: "Days"

--- a/migrations/20180907155542_add_earliest_date_validation.js
+++ b/migrations/20180907155542_add_earliest_date_validation.js
@@ -1,0 +1,44 @@
+const formatAlterTableEnumSql = (tableName, columnName, enums) => {
+  const constraintName = `${tableName}_${columnName}_check`;
+  return [
+    `ALTER TABLE "${tableName}" DROP CONSTRAINT IF EXISTS "${constraintName}";`,
+    `ALTER TABLE "${tableName}" ADD CONSTRAINT "${constraintName}" CHECK ("${columnName}" = ANY (ARRAY['${enums.join(
+      "'::text, '"
+    )}'::text]));`
+  ].join("\n");
+};
+
+exports.up = async function(knex) {
+  await knex.raw(
+    formatAlterTableEnumSql("Validation_AnswerRules", "validationType", [
+      "minValue",
+      "maxValue",
+      "earliestDate"
+    ])
+  );
+
+  const ids = await knex
+    .select("Answers.id")
+    .from("Answers")
+    .where({ type: "Date" });
+
+  const inserts = ids.map(({ id }) =>
+    knex("Validation_AnswerRules").insert({
+      AnswerId: id,
+      validationType: "earliestDate",
+      config: {
+        inclusive: false,
+        offset: {
+          value: 0,
+          unit: "Days"
+        },
+        relativePostion: "Before"
+      }
+    })
+  );
+  return Promise.resolve(inserts);
+};
+
+exports.down = function() {
+  return Promise.resolve();
+};

--- a/migrations/20180907155542_add_earliest_date_validation.js
+++ b/migrations/20180907155542_add_earliest_date_validation.js
@@ -31,7 +31,7 @@ exports.up = async function(knex) {
           value: 0,
           unit: "Days"
         },
-        relativePostion: "Before"
+        relativePosition: "Before"
       }
     })
   );

--- a/migrations/20180910103658_convert_validation_custom_type.js
+++ b/migrations/20180910103658_convert_validation_custom_type.js
@@ -1,0 +1,8 @@
+exports.up = async function(knex) {
+  await knex.raw(
+    `ALTER TABLE "Validation_AnswerRules"
+  	ALTER COLUMN "custom" TYPE text;`
+  );
+};
+
+exports.down = () => Promise.resolve();

--- a/migrations/20180910103658_convert_validation_custom_type.js
+++ b/migrations/20180910103658_convert_validation_custom_type.js
@@ -1,8 +1,0 @@
-exports.up = async function(knex) {
-  await knex.raw(
-    `ALTER TABLE "Validation_AnswerRules"
-  	ALTER COLUMN "custom" TYPE text;`
-  );
-};
-
-exports.down = () => Promise.resolve();

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^6.0.0",
-    "eq-author-graphql-schema": "^0.25.0",
+    "eq-author-graphql-schema": "^0.26.0",
     "express": "^4.15.3",
     "express-pino-logger": "^3.0.1",
     "graphql": "^0.13.2",

--- a/repositories/ValidationRepository.js
+++ b/repositories/ValidationRepository.js
@@ -18,7 +18,7 @@ const getInputType = flow(
 const updateValidationRule = input => {
   const { custom, ...config } = input[getInputType(input)];
   return Validation.update(input.id, {
-    custom,
+    custom: JSON.stringify(custom),
     config: JSON.stringify(config)
   }).then(head);
 };

--- a/repositories/ValidationRepository.js
+++ b/repositories/ValidationRepository.js
@@ -16,10 +16,11 @@ const getInputType = flow(
 );
 
 const updateValidationRule = input => {
-  const { custom, inclusive } = input[getInputType(input)];
-  return Validation.update(input.id, { custom, config: { inclusive } }).then(
-    head
-  );
+  const { custom, ...config } = input[getInputType(input)];
+  return Validation.update(input.id, {
+    custom,
+    config: JSON.stringify(config)
+  }).then(head);
 };
 
 Object.assign(module.exports, {

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -359,6 +359,8 @@ const Resolvers = {
       switch (validationEntity) {
         case "number":
           return "NumberValidation";
+        case "date":
+          return "DateValidation";
 
         default:
           throw new TypeError(
@@ -397,6 +399,14 @@ const Resolvers = {
       )
   },
 
+  DateValidation: {
+    earliestDate: (answer, args, ctx) =>
+      ctx.repositories.Validation.findByAnswerIdAndValidationType(
+        answer,
+        "earliestDate"
+      )
+  },
+
   MinValueValidationRule: {
     enabled: ({ enabled }) => enabled,
     inclusive: ({ config }) => config.inclusive,
@@ -407,6 +417,11 @@ const Resolvers = {
     enabled: ({ enabled }) => enabled,
     inclusive: ({ config }) => config.inclusive,
     custom: ({ custom }) => custom
+  },
+
+  EarliestDateValidationRule: {
+    offset: ({ config: { offset } }) => offset,
+    relativePostion: ({ config: { relativePostion } }) => relativePostion
   },
 
   Metadata: {

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -305,7 +305,9 @@ const Resolvers = {
     page: (answer, args, ctx) =>
       ctx.repositories.QuestionPage.getById(answer.questionPageId),
     validation: answer =>
-      getValidationEntity(answer.type) !== "number" ? null : answer
+      ["number", "date"].includes(getValidationEntity(answer.type))
+        ? answer
+        : null
   },
 
   CompositeAnswer: {

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -424,7 +424,7 @@ const Resolvers = {
   EarliestDateValidationRule: {
     custom: ({ custom }) => (custom ? new Date(custom) : null),
     offset: ({ config: { offset } }) => offset,
-    relativePostion: ({ config: { relativePostion } }) => relativePostion
+    relativePosition: ({ config: { relativePosition } }) => relativePosition
   },
 
   Metadata: {

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -377,6 +377,8 @@ const Resolvers = {
           return "MaxValueValidationRule";
         case "minValue":
           return "MinValueValidationRule";
+        case "earliestDate":
+          return "EarliestDateValidationRule";
 
         default:
           throw new TypeError(
@@ -420,6 +422,7 @@ const Resolvers = {
   },
 
   EarliestDateValidationRule: {
+    custom: ({ custom }) => (custom ? new Date(custom) : null),
     offset: ({ config: { offset } }) => offset,
     relativePostion: ({ config: { relativePostion } }) => relativePostion
   },

--- a/schema/resolversTests/validation.test.js
+++ b/schema/resolversTests/validation.test.js
@@ -225,7 +225,7 @@ describe("resolvers", () => {
             value: 0,
             unit: "Days"
           },
-          relativePostion: "Before",
+          relativePosition: "Before",
           custom: null
         }
       });
@@ -246,7 +246,7 @@ describe("resolvers", () => {
             value: 8,
             unit: "Months"
           },
-          relativePostion: "After"
+          relativePosition: "After"
         }
       });
       const expected = {
@@ -256,7 +256,7 @@ describe("resolvers", () => {
           value: 8,
           unit: "Months"
         },
-        relativePostion: "After"
+        relativePosition: "After"
       };
       expect(result).toMatchObject(expected);
     });

--- a/schema/resolversTests/validation.test.js
+++ b/schema/resolversTests/validation.test.js
@@ -83,6 +83,9 @@ const mutateValidationParameters = async input => {
     },
     ctx
   );
+  if (result.errors) {
+    throw new Error(result.errors[0]);
+  }
   return result.data.updateValidationRule;
 };
 
@@ -227,9 +230,35 @@ describe("resolvers", () => {
         }
       });
 
-      expect(validationObject(validation.earliestDate.id)).toMatchObject(
-        validation
+      expect(validation).toMatchObject(
+        validationObject(validation.earliestDate.id)
       );
+    });
+
+    it("should be able to update earliest date properties", async () => {
+      const answer = await createNewAnswer(firstPage, "Date");
+      const validation = await queryAnswerValidations(answer.id);
+      const result = await mutateValidationParameters({
+        id: validation.earliestDate.id,
+        earliestDateInput: {
+          custom: "2017-01-01",
+          offset: {
+            value: 8,
+            unit: "Months"
+          },
+          relativePostion: "After"
+        }
+      });
+      const expected = {
+        id: validation.earliestDate.id,
+        customDate: "2017-01-01",
+        offset: {
+          value: 8,
+          unit: "Months"
+        },
+        relativePostion: "After"
+      };
+      expect(result).toMatchObject(expected);
     });
   });
 });

--- a/schema/resolversTests/validation.test.js
+++ b/schema/resolversTests/validation.test.js
@@ -57,6 +57,9 @@ const queryAnswerValidations = async id => {
     },
     ctx
   );
+  if (result.errors) {
+    throw new Error(result.errors[0]);
+  }
   return result.data.answer.validation;
 };
 
@@ -214,6 +217,7 @@ describe("resolvers", () => {
       const validationObject = id => ({
         earliestDate: {
           id,
+          enabled: false,
           offset: {
             value: 0,
             unit: "Days"
@@ -223,8 +227,8 @@ describe("resolvers", () => {
         }
       });
 
-      expect(validation).toMatchObject(
-        validationObject(validation.earliestDate.id)
+      expect(validationObject(validation.earliestDate.id)).toMatchObject(
+        validation
       );
     });
   });

--- a/schema/resolversTests/validation.test.js
+++ b/schema/resolversTests/validation.test.js
@@ -43,6 +43,9 @@ const createNewAnswer = async ({ id: pageId }, type) => {
   };
 
   const result = await executeQuery(createAnswerMutation, { input }, ctx);
+  if (result.errors) {
+    throw new Error(result.errors[0]);
+  }
   return result.data.createAnswer;
 };
 
@@ -97,100 +100,132 @@ describe("resolvers", () => {
     firstPage = first(pages);
   });
 
-  it("should create min and max validation db entries for Currency and Number answers", async () => {
-    const currencyAnswer = await createNewAnswer(firstPage, "Currency");
-    const currencyValidation = await queryAnswerValidations(currencyAnswer.id);
+  describe("All", () => {
+    it("can toggle any validation rule on and off without affecting another", async () => {
+      const currencyAnswer = await createNewAnswer(firstPage, "Currency");
+      let currencyValidation = await queryAnswerValidations(currencyAnswer.id);
 
-    const numberAnswer = await createNewAnswer(firstPage, "Number");
-    const numberValidation = await queryAnswerValidations(numberAnswer.id);
+      await mutateValidationToggle({
+        id: currencyValidation.minValue.id,
+        enabled: true
+      });
 
-    const validationObject = (minValueId, maxValueId) => ({
-      minValue: {
-        id: minValueId,
-        enabled: false,
-        inclusive: false,
-        custom: null
-      },
-      maxValue: {
-        id: maxValueId,
-        enabled: false,
-        inclusive: false,
-        custom: null
-      }
+      currencyValidation = await queryAnswerValidations(currencyAnswer.id);
+
+      expect(currencyValidation.minValue).toHaveProperty("enabled", true);
+      expect(currencyValidation.maxValue).toHaveProperty("enabled", false);
+
+      await mutateValidationToggle({
+        id: currencyValidation.minValue.id,
+        enabled: false
+      });
+
+      currencyValidation = await queryAnswerValidations(currencyAnswer.id);
+
+      expect(currencyValidation.minValue).toHaveProperty("enabled", false);
+      expect(currencyValidation.maxValue).toHaveProperty("enabled", false);
     });
-
-    expect(currencyValidation).toMatchObject(
-      validationObject(
-        currencyValidation.minValue.id,
-        currencyValidation.maxValue.id
-      )
-    );
-    expect(numberValidation).toMatchObject(
-      validationObject(
-        numberValidation.minValue.id,
-        numberValidation.maxValue.id
-      )
-    );
   });
 
-  it("can toggle min validation rule on and off without affecting max", async () => {
-    const currencyAnswer = await createNewAnswer(firstPage, "Currency");
-    let currencyValidation = await queryAnswerValidations(currencyAnswer.id);
+  describe("Number and Currency", () => {
+    it("should create min and max validation db entries for Currency and Number answers", async () => {
+      const currencyAnswer = await createNewAnswer(firstPage, "Currency");
+      const currencyValidation = await queryAnswerValidations(
+        currencyAnswer.id
+      );
 
-    await mutateValidationToggle({
-      id: currencyValidation.minValue.id,
-      enabled: true
+      const numberAnswer = await createNewAnswer(firstPage, "Number");
+      const numberValidation = await queryAnswerValidations(numberAnswer.id);
+
+      const validationObject = (minValueId, maxValueId) => ({
+        minValue: {
+          id: minValueId,
+          enabled: false,
+          inclusive: false,
+          custom: null
+        },
+        maxValue: {
+          id: maxValueId,
+          enabled: false,
+          inclusive: false,
+          custom: null
+        }
+      });
+
+      expect(currencyValidation).toMatchObject(
+        validationObject(
+          currencyValidation.minValue.id,
+          currencyValidation.maxValue.id
+        )
+      );
+      expect(numberValidation).toMatchObject(
+        validationObject(
+          numberValidation.minValue.id,
+          numberValidation.maxValue.id
+        )
+      );
     });
 
-    currencyValidation = await queryAnswerValidations(currencyAnswer.id);
+    it("can update inclusive and custom min values", async () => {
+      const currencyAnswer = await createNewAnswer(firstPage, "Currency");
+      const currencyValidation = await queryAnswerValidations(
+        currencyAnswer.id
+      );
 
-    expect(currencyValidation.minValue).toHaveProperty("enabled", true);
-    expect(currencyValidation.maxValue).toHaveProperty("enabled", false);
-
-    await mutateValidationToggle({
-      id: currencyValidation.minValue.id,
-      enabled: false
-    });
-
-    currencyValidation = await queryAnswerValidations(currencyAnswer.id);
-
-    expect(currencyValidation.minValue).toHaveProperty("enabled", false);
-    expect(currencyValidation.maxValue).toHaveProperty("enabled", false);
-  });
-
-  it("can update inclusive and custom min values", async () => {
-    const currencyAnswer = await createNewAnswer(firstPage, "Currency");
-    const currencyValidation = await queryAnswerValidations(currencyAnswer.id);
-
-    const result = await mutateValidationParameters({
-      id: currencyValidation.minValue.id,
-      minValueInput: {
+      const result = await mutateValidationParameters({
+        id: currencyValidation.minValue.id,
+        minValueInput: {
+          custom: 10,
+          inclusive: true
+        }
+      });
+      expect(result).toMatchObject({
+        id: currencyValidation.minValue.id,
         custom: 10,
         inclusive: true
-      }
+      });
     });
-    expect(result).toMatchObject({
-      id: currencyValidation.minValue.id,
-      custom: 10,
-      inclusive: true
+
+    it("can update inclusive and custom max values", async () => {
+      const currencyAnswer = await createNewAnswer(firstPage, "Currency");
+      const currencyValidation = await queryAnswerValidations(
+        currencyAnswer.id
+      );
+
+      const result = await mutateValidationParameters({
+        id: currencyValidation.maxValue.id,
+        maxValueInput: {
+          custom: 10,
+          inclusive: true
+        }
+      });
+      expect(result).toMatchObject({
+        id: currencyValidation.maxValue.id,
+        custom: 10,
+        inclusive: true
+      });
     });
   });
 
-  it("can update inclusive and custom max values", async () => {
-    const currencyAnswer = await createNewAnswer(firstPage, "Currency");
-    const currencyValidation = await queryAnswerValidations(currencyAnswer.id);
+  describe("Date", () => {
+    it("should create earliest validation db entries for Date answers", async () => {
+      const answer = await createNewAnswer(firstPage, "Date");
+      const validation = await queryAnswerValidations(answer.id);
+      const validationObject = id => ({
+        earliestDate: {
+          id,
+          offset: {
+            value: 0,
+            unit: "Days"
+          },
+          relativePostion: "Before",
+          custom: null
+        }
+      });
 
-    const result = await mutateValidationParameters({
-      id: currencyValidation.maxValue.id,
-      maxValueInput: {
-        custom: 10,
-        inclusive: true
-      }
-    });
-    expect(result).toMatchObject({
-      id: currencyValidation.maxValue.id,
-      custom: 10,
-      inclusive: true
+      expect(validation).toMatchObject(
+        validationObject(validation.earliestDate.id)
+      );
     });
   });
 });

--- a/tests/utils/graphql.js
+++ b/tests/utils/graphql.js
@@ -576,7 +576,7 @@ const getAnswerValidations = `
                value
                unit
              }
-             relativePostion
+             relativePosition
            }
          }
        }
@@ -612,7 +612,7 @@ mutation updateValidation($input: UpdateValidationRuleInput!){
         value
         unit
       }
-      relativePostion
+      relativePosition
     }
   }
 }

--- a/tests/utils/graphql.js
+++ b/tests/utils/graphql.js
@@ -576,6 +576,7 @@ const getAnswerValidations = `
                value
                unit
              }
+             relativePostion
            }
          }
        }
@@ -604,6 +605,14 @@ mutation updateValidation($input: UpdateValidationRuleInput!){
     ...on MaxValueValidationRule {
       custom
       inclusive
+    }
+    ...on EarliestDateValidationRule {
+      customDate: custom
+      offset {
+        value
+        unit
+      }
+      relativePostion
     }
   }
 }

--- a/tests/utils/graphql.js
+++ b/tests/utils/graphql.js
@@ -530,7 +530,7 @@ mutation UpdateAnswer($input: UpdateAnswerInput!) {
     mandatory
     ...on CompositeAnswer{
       childAnswers{
-        id 
+        id
         label
       }
     }
@@ -566,6 +566,17 @@ const getAnswerValidations = `
             inclusive
             custom
           }
+         }
+         ...on DateValidation {
+           earliestDate {
+             id
+             enabled
+             custom
+             offset {
+               value
+               unit
+             }
+           }
          }
        }
      }

--- a/utils/defaultAnswerValidations.js
+++ b/utils/defaultAnswerValidations.js
@@ -1,9 +1,11 @@
 const answerTypeMap = {
-  number: ["Currency", "Number"]
+  number: ["Currency", "Number"],
+  date: ["Date"]
 };
 
 const validationRuleMap = {
-  number: ["minValue", "maxValue"]
+  number: ["minValue", "maxValue"],
+  date: ["earliestDate"]
 };
 
 const defaultValidationRuleConfigs = {
@@ -12,6 +14,14 @@ const defaultValidationRuleConfigs = {
   },
   maxValue: {
     inclusive: false
+  },
+  earliestDate: {
+    inclusive: false,
+    offset: {
+      value: 0,
+      unit: "Days"
+    },
+    relativePostion: "Before"
   }
 };
 

--- a/utils/defaultAnswerValidations.js
+++ b/utils/defaultAnswerValidations.js
@@ -16,7 +16,6 @@ const defaultValidationRuleConfigs = {
     inclusive: false
   },
   earliestDate: {
-    inclusive: false,
     offset: {
       value: 0,
       unit: "Days"

--- a/utils/defaultAnswerValidations.js
+++ b/utils/defaultAnswerValidations.js
@@ -20,7 +20,7 @@ const defaultValidationRuleConfigs = {
       value: 0,
       unit: "Days"
     },
-    relativePostion: "Before"
+    relativePosition: "Before"
   }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,9 +1297,9 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-eq-author-graphql-schema@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.25.0.tgz#0125702e18c669d74f6bcd8d7462836ddcc27515"
+eq-author-graphql-schema@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.26.0.tgz#7b4c6dfb735dc9aa8e8e9665a9b32ef805673beb"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
### What is the context of this PR?
1. Add earliest date validation to all date answers and new date answers
2. Allow for reading of the earliest date validation
3. Allow for updating of the config of an earliest date validation

### How to review
#### Reading
Given you have a date answer with an ID of 19
```graphql
query QuestionPage($id: ID!) {
  answer(id: $id) {
    id
    ... on BasicAnswer {
      validation {
        ... on DateValidation {
          earliestDate {
            id
            enabled
            custom
            offset {
              value
              unit
            }
            relativePostion
          }
        }
      }
    }
  }
}
```
Input:
```
{ "id": 19 }
```

#### Updating
Given you have an earliest date validation with ID 35

```graphql
mutation updateValidation($input: UpdateValidationRuleInput!) {
  updateValidationRule(input: $input) {
    id
    enabled
    ... on EarliestDateValidationRule {
      custom
      offset {
        value
        unit
      }
      relativePostion
    }
  }
}
```
Input:
```json
{
  "input":{
    "id": 35,
    "earliestDateInput": {
      "offset": {
        "value": 10,
        "unit": "Months"
      },
      "relativePostion": "After",
      "custom": "2017-01-01"
    }
  }
}
```

This relies on https://github.com/ONSdigital/eq-author-graphql-schema/pull/62