### PR TITLE
Implement displayTitle resolvers

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^6.0.0",
-    "eq-author-graphql-schema": "^0.26.0",
+    "eq-author-graphql-schema": "^0.27.0",
     "express": "^4.15.3",
     "express-pino-logger": "^3.0.1",
     "graphql": "^0.13.2",

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -1,6 +1,7 @@
 const { GraphQLDate } = require("graphql-iso-date");
 const { includes, isNil } = require("lodash");
 const GraphQLJSON = require("graphql-type-json");
+const { getName } = require("../utils/getName");
 const formatRichText = require("../utils/formatRichText");
 const {
   getValidationEntity
@@ -178,11 +179,13 @@ const Resolvers = {
     totalSectionCount: (questionnaireId, args, ctx) =>
       ctx.repositories.Section.getSectionCount(questionnaireId)
   },
+
   Section: {
     pages: (section, args, ctx) =>
       ctx.repositories.Page.findAll({ sectionId: section.id }),
     questionnaire: (section, args, ctx) =>
       ctx.repositories.Questionnaire.getById(section.questionnaireId),
+    displayName: section => getName(section, "Section"),
     title: (page, args) => formatRichText(page.title, args.format),
     position: ({ position, id }, args, ctx) => {
       if (position !== undefined) {
@@ -216,6 +219,7 @@ const Resolvers = {
       ctx.repositories.Routing.findRoutingRuleSetByQuestionPageId({
         questionPageId
       }),
+    displayName: page => getName(page, "QuestionPage"),
     title: (page, args) => formatRichText(page.title, args.format)
   },
 
@@ -307,14 +311,16 @@ const Resolvers = {
     validation: answer =>
       ["number", "date"].includes(getValidationEntity(answer.type))
         ? answer
-        : null
+        : null,
+    displayName: answer => getName(answer, "BasicAnswer")
   },
 
   CompositeAnswer: {
     childAnswers: (answer, args, ctx) =>
       ctx.repositories.Answer.splitComposites(answer),
     page: (answer, args, ctx) =>
-      ctx.repositories.QuestionPage.getById(answer.questionPageId)
+      ctx.repositories.QuestionPage.getById(answer.questionPageId),
+    displayName: answer => getName(answer, "CompositeAnswer")
   },
 
   MultipleChoiceAnswer: {
@@ -344,12 +350,14 @@ const Resolvers = {
         answer,
         option
       };
-    }
+    },
+    displayName: answer => getName(answer, "MultipleChoiceAnswer")
   },
 
   Option: {
     answer: ({ answerId }, args, ctx) =>
-      ctx.repositories.Answer.getById(answerId)
+      ctx.repositories.Answer.getById(answerId),
+    displayName: option => getName(option, "Option")
   },
 
   ValidationType: {

--- a/schema/resolvers.test.js
+++ b/schema/resolvers.test.js
@@ -886,6 +886,132 @@ describe("resolvers", () => {
     expect(result).toMatchObject(expected);
   });
 
+  it("should resolve displayName for section", async () => {
+    const getSectionWithDisplayName = `
+      query GetSection($id: ID!) {
+        section(id: $id) {
+          id
+          displayName
+        }   
+      }
+      `;
+    const {
+      data: { section }
+    } = await executeQuery(
+      getSectionWithDisplayName,
+      {
+        id: first(sections).id
+      },
+      ctx
+    );
+
+    expect(section).toHaveProperty("displayName");
+  });
+
+  it("should resolve displayName for question page", async () => {
+    const getQuestionPageWithDisplayName = `
+      query GetQuestionPage($id: ID!) {
+        questionPage(id: $id) {
+          id
+          displayName
+        }   
+      }
+      `;
+    const {
+      data: { questionPage }
+    } = await executeQuery(
+      getQuestionPageWithDisplayName,
+      {
+        id: firstPage.id
+      },
+      ctx
+    );
+
+    expect(questionPage).toHaveProperty("displayName");
+  });
+
+  it("should resolve displayName for basic answer", async () => {
+    const { id } = await createNewAnswer(firstPage, "Number");
+
+    const getBasicAnswerWithDisplayName = `
+      query GetAnswer($id: ID!) {
+        answer(id: $id) {
+          id
+          displayName
+        }   
+      }
+      `;
+
+    const {
+      data: { answer }
+    } = await executeQuery(
+      getBasicAnswerWithDisplayName,
+      {
+        id: id
+      },
+      ctx
+    );
+
+    expect(answer).toHaveProperty("displayName");
+  });
+
+  it("should resolve displayName for composite answer", async () => {
+    const { id } = await createNewAnswer(firstPage, "DateRange");
+
+    const getBasicAnswerWithDisplayName = `
+      query GetAnswer($id: ID!) {
+        answer(id: $id) {
+          id
+          displayName
+        }   
+      }
+      `;
+
+    const {
+      data: { answer }
+    } = await executeQuery(
+      getBasicAnswerWithDisplayName,
+      {
+        id: id
+      },
+      ctx
+    );
+
+    expect(answer).toHaveProperty("displayName");
+  });
+
+  it("should resolve displayName for multiple choice answer", async () => {
+    const { id } = await createNewAnswer(firstPage, "Radio");
+
+    const getBasicAnswerWithDisplayName = `
+      query GetAnswer($id: ID!) {
+        answer(id: $id) {
+          id
+          displayName
+          ... on MultipleChoiceAnswer {
+            options {
+              id
+              displayName
+            }
+          }
+        }   
+      }
+      `;
+
+    const {
+      data: { answer }
+    } = await executeQuery(
+      getBasicAnswerWithDisplayName,
+      {
+        id: id
+      },
+      ctx
+    );
+
+    expect(answer).toHaveProperty("displayName");
+    expect(first(answer.options)).toHaveProperty("displayName");
+  });
+
   describe("routing", () => {
     const mutate = async input => createNewRoutingRule(input);
     const newRoutingRule = async input =>

--- a/utils/getName.js
+++ b/utils/getName.js
@@ -1,0 +1,25 @@
+const { find, pick, isEmpty } = require("lodash");
+const { stripTags } = require("./html");
+
+const defaultNames = {
+  Section: "Untitled Section",
+  QuestionPage: "Untitled Page",
+  Option: "Untitled Label",
+  BasicAnswer: "Untitled Answer",
+  MultipleChoiceAnswer: "Untitled Answer",
+  CompositeAnswer: "Untitled Answer"
+};
+
+const getName = (entity, typeName) => {
+  const title = find(
+    pick(entity, ["alias", "title", "label"]),
+    value => !isEmpty(stripTags(value))
+  );
+
+  return title ? stripTags(title) : defaultNames[typeName];
+};
+
+module.exports = {
+  getName,
+  defaultNames
+};

--- a/utils/getName.test.js
+++ b/utils/getName.test.js
@@ -1,0 +1,64 @@
+const { keys, map } = require("lodash");
+const { getName, defaultNames } = require("./getName");
+
+describe("getName", () => {
+  let entity;
+
+  it("should correctly use default names", () => {
+    entity = {
+      alias: "",
+      title: "",
+      label: ""
+    };
+
+    map(keys(defaultNames), typeName =>
+      expect(getName(entity, typeName)).toEqual(defaultNames[typeName])
+    );
+  });
+
+  it("should use correct key", () => {
+    entity = {
+      alias: "",
+      title: "I am a title",
+      label: "I am a label"
+    };
+
+    map(keys(defaultNames), typeName =>
+      expect(getName(entity, typeName)).toEqual(entity.title)
+    );
+
+    entity = {
+      alias: "",
+      title: "",
+      label: "I am a label"
+    };
+
+    map(keys(defaultNames), typeName =>
+      expect(getName(entity, typeName)).toEqual(entity.label)
+    );
+  });
+
+  it("should ignore any html markup", () => {
+    entity = {
+      alias: "<p></p>",
+      title: "<p>I am a title</p>",
+      label: "<p>I am a label</p>"
+    };
+
+    map(keys(defaultNames), typeName =>
+      expect(getName(entity, typeName)).toEqual("I am a title")
+    );
+  });
+
+  it("should ignore invalid keys", () => {
+    entity = {
+      alias: "<p></p>",
+      foo: "I am a title",
+      label: "I am a label"
+    };
+
+    map(keys(defaultNames), typeName =>
+      expect(getName(entity, typeName)).toEqual(entity.label)
+    );
+  });
+});

--- a/utils/html.js
+++ b/utils/html.js
@@ -1,0 +1,12 @@
+const cheerio = require("cheerio");
+const { isNull, toString } = require("lodash");
+
+const isHtml = value => !isNull(cheerio(value).html());
+
+const stripTags = value =>
+  isHtml(toString(value)) ? cheerio(value).text() : value;
+
+module.exports = {
+  isHtml,
+  stripTags
+};

--- a/utils/html.test.js
+++ b/utils/html.test.js
@@ -1,0 +1,40 @@
+const { isHtml, stripTags } = require("./html");
+
+describe("html", () => {
+  describe("isHtml", () => {
+    it("should correctly determine if value is HTML", () => {
+      expect(isHtml("<p>test</p>")).toEqual(true);
+      expect(isHtml("<body<h1>test</h1></body>")).toEqual(true);
+      expect(isHtml("<dsa i am valid html >")).toEqual(true);
+    });
+
+    it("should correctly determine if value is not HTML", () => {
+      expect(isHtml("< i am NOT valid html >")).toEqual(false);
+      expect(isHtml("Just text...")).toEqual(false);
+      expect(isHtml("<>")).toEqual(false);
+      expect(isHtml("")).toEqual(false);
+      expect(isHtml(true)).toEqual(false);
+      expect(isHtml(null)).toEqual(false);
+      expect(isHtml(false)).toEqual(false);
+      expect(isHtml([])).toEqual(false);
+      expect(isHtml({})).toEqual(false);
+      expect(isHtml(1)).toEqual(false);
+    });
+  });
+
+  describe("stripTags", () => {
+    it("should correctly strip html tags", () => {
+      expect(stripTags("<p>test</p>")).toEqual("test");
+      expect(stripTags("<p></p>")).toEqual("");
+      expect(stripTags("test")).toEqual("test");
+      expect(stripTags("")).toEqual("");
+      expect(stripTags(true)).toEqual(true);
+      expect(stripTags(null)).toEqual(null);
+      expect(stripTags(false)).toEqual(false);
+      expect(stripTags([])).toEqual([]);
+      expect(stripTags("<p>[]</p>")).toEqual("[]");
+      expect(stripTags({})).toEqual({});
+      expect(stripTags(1)).toEqual(1);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,9 +1297,9 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-eq-author-graphql-schema@^0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.26.0.tgz#7b4c6dfb735dc9aa8e8e9665a9b32ef805673beb"
+eq-author-graphql-schema@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.27.0.tgz#333ea6a89a234421b5d987089112fa0c940e83d5"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
### What is the context of this PR?

We have inconsistent display values scattered through the author application. In some places, we display titles, in other places we display labels and in other places we have inconsistent unnamed or untitled placeholders.

This technical improvement makes it the responsibility of the API to provide the most relevant displayable value.

More info can be found here: https://github.com/ONSdigital/eq-author/wiki/Display-names

### How to review

- Run tests

### Dependencies 

- [x] https://github.com/ONSdigital/eq-author-graphql-schema/pull/63
