### PR TITLE
488 - Add latest date validation for date answers

### DIFF
--- a/migrations/20180914145815_add_latest_date_validation.js
+++ b/migrations/20180914145815_add_latest_date_validation.js
@@ -1,0 +1,44 @@
+const formatAlterTableEnumSql = (tableName, columnName, enums) => {
+  const constraintName = `${tableName}_${columnName}_check`;
+  return [
+    `ALTER TABLE "${tableName}" DROP CONSTRAINT IF EXISTS "${constraintName}";`,
+    `ALTER TABLE "${tableName}" ADD CONSTRAINT "${constraintName}" CHECK ("${columnName}" = ANY (ARRAY['${enums.join(
+      "'::text, '"
+    )}'::text]));`
+  ].join("\n");
+};
+
+exports.up = async function(knex) {
+  await knex.raw(
+    formatAlterTableEnumSql("Validation_AnswerRules", "validationType", [
+      "minValue",
+      "maxValue",
+      "earliestDate",
+      "latestDate"
+    ])
+  );
+
+  const ids = await knex
+    .select("Answers.id")
+    .from("Answers")
+    .where({ type: "Date" });
+
+  const inserts = ids.map(({ id }) =>
+    knex("Validation_AnswerRules").insert({
+      AnswerId: id,
+      validationType: "latestDate",
+      config: {
+        offset: {
+          value: 0,
+          unit: "Days"
+        },
+        relativePosition: "Before"
+      }
+    })
+  );
+  return Promise.resolve(inserts);
+};
+
+exports.down = function() {
+  return Promise.resolve();
+};

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^6.0.0",
-    "eq-author-graphql-schema": "^0.27.0",
+    "eq-author-graphql-schema": "^0.28.0",
     "express": "^4.15.3",
     "express-pino-logger": "^3.0.1",
     "graphql": "^0.13.2",

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -387,6 +387,8 @@ const Resolvers = {
           return "MinValueValidationRule";
         case "earliestDate":
           return "EarliestDateValidationRule";
+        case "latestDate":
+          return "LatestDateValidationRule";
 
         default:
           throw new TypeError(
@@ -414,6 +416,11 @@ const Resolvers = {
       ctx.repositories.Validation.findByAnswerIdAndValidationType(
         answer,
         "earliestDate"
+      ),
+    latestDate: (answer, args, ctx) =>
+      ctx.repositories.Validation.findByAnswerIdAndValidationType(
+        answer,
+        "latestDate"
       )
   },
 
@@ -430,6 +437,12 @@ const Resolvers = {
   },
 
   EarliestDateValidationRule: {
+    custom: ({ custom }) => (custom ? new Date(custom) : null),
+    offset: ({ config: { offset } }) => offset,
+    relativePosition: ({ config: { relativePosition } }) => relativePosition
+  },
+
+  LatestDateValidationRule: {
     custom: ({ custom }) => (custom ? new Date(custom) : null),
     offset: ({ config: { offset } }) => offset,
     relativePosition: ({ config: { relativePosition } }) => relativePosition

--- a/tests/utils/graphql.js
+++ b/tests/utils/graphql.js
@@ -578,6 +578,16 @@ const getAnswerValidations = `
              }
              relativePosition
            }
+           latestDate {
+             id
+             enabled
+             custom
+             offset {
+               value
+               unit
+             }
+             relativePosition
+           }
          }
        }
      }
@@ -607,6 +617,14 @@ mutation updateValidation($input: UpdateValidationRuleInput!){
       inclusive
     }
     ...on EarliestDateValidationRule {
+      customDate: custom
+      offset {
+        value
+        unit
+      }
+      relativePosition
+    }
+    ...on LatestDateValidationRule {
       customDate: custom
       offset {
         value

--- a/utils/defaultAnswerValidations.js
+++ b/utils/defaultAnswerValidations.js
@@ -5,7 +5,7 @@ const answerTypeMap = {
 
 const validationRuleMap = {
   number: ["minValue", "maxValue"],
-  date: ["earliestDate"]
+  date: ["earliestDate", "latestDate"]
 };
 
 const defaultValidationRuleConfigs = {
@@ -16,6 +16,13 @@ const defaultValidationRuleConfigs = {
     inclusive: false
   },
   earliestDate: {
+    offset: {
+      value: 0,
+      unit: "Days"
+    },
+    relativePosition: "Before"
+  },
+  latestDate: {
     offset: {
       value: 0,
       unit: "Days"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,9 +1297,9 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-eq-author-graphql-schema@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.27.0.tgz#333ea6a89a234421b5d987089112fa0c940e83d5"
+eq-author-graphql-schema@^0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.28.0.tgz#7567804deefba6728b70d5707d302eef570f4495"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
### What is the context of this PR?
Adds the ability to hold latest date validations against date answers.

### How to review 
#### Reading
Given you have a date answer with an ID of 19
```graphql
query QuestionPage($id: ID!) {
  answer(id: $id) {
    id
    ... on BasicAnswer {
      validation {
        ... on DateValidation {
          latestDate {
            id
            enabled
            custom
            offset {
              value
              unit
            }
            relativePostion
          }
        }
      }
    }
  }
}
```
Input:
```
{ "id": 19 }
```

#### Updating
Given you have an latest date validation with ID 35

```graphql
mutation updateValidation($input: UpdateValidationRuleInput!) {
  updateValidationRule(input: $input) {
    id
    enabled
    ... on LatestDateValidationRule {
      custom
      offset {
        value
        unit
      }
      relativePostion
    }
  }
}
```
Input:
```json
{
  "input":{
    "id": 35,
    "latestDateInput": {
      "offset": {
        "value": 10,
        "unit": "Months"
      },
      "relativePostion": "After",
      "custom": "2017-01-01"
    }
  }
}
```
## Dependencies
- [x] - Schema - https://github.com/ONSdigital/eq-author-graphql-schema/pull/64