### PR TITLE
Changing the default latest date config to match designs

### DIFF
--- a/migrations/20180919085754_correcting_default_latest_date_validation.js
+++ b/migrations/20180919085754_correcting_default_latest_date_validation.js
@@ -1,0 +1,17 @@
+exports.up = async function(knex, Promise) {
+  const ids = await knex
+    .select("Validation_AnswerRules.id")
+    .from("Validation_AnswerRules")
+    .where({ validationType: "latestDate" });
+
+  const updates = ids.map(({ id }) =>
+    knex.raw(
+      `update "Validation_AnswerRules" set "config" = '{"offset":{"value":0,"unit":"Days"},"relativePosition":"After"}' where "id" = ${id}`
+    )
+  );
+  return Promise.all(updates);
+};
+
+exports.down = function(knex, Promise) {
+  return Promise.resolve();
+};

--- a/schema/resolversTests/validation.test.js
+++ b/schema/resolversTests/validation.test.js
@@ -214,7 +214,7 @@ describe("resolvers", () => {
   });
 
   describe("Date", () => {
-    it("should create earliest validation db entries for Date answers", async () => {
+    it("should create earliest ans latest validation db entries for Date answers", async () => {
       const answer = await createNewAnswer(firstPage, "Date");
       const validation = await queryAnswerValidations(answer.id);
       const validationObject = (earliestId, latestId) => ({
@@ -234,7 +234,7 @@ describe("resolvers", () => {
             value: 0,
             unit: "Days"
           },
-          relativePosition: "Before",
+          relativePosition: "After",
           custom: null
         }
       });

--- a/utils/defaultAnswerValidations.js
+++ b/utils/defaultAnswerValidations.js
@@ -27,7 +27,7 @@ const defaultValidationRuleConfigs = {
       value: 0,
       unit: "Days"
     },
-    relativePosition: "Before"
+    relativePosition: "After"
   }
 };
 


### PR DESCRIPTION
### What is the context of this PR?
There was a small issue where the default values for the config on latest date didn't quite match the designs. This Pr brings them back into line with one another.

### How to review 
Tests should pass and the migration should successfully change all latest date configs to the correct value.
