### PR TITLE
Add alias to Sections

### DIFF
--- a/migrations/20180918144616_add_alias_to_sections.js
+++ b/migrations/20180918144616_add_alias_to_sections.js
@@ -1,0 +1,17 @@
+exports.up = async function(knex) {
+  await knex.schema.table("Sections", table => table.string("alias"));
+  await knex.raw(`DROP VIEW "SectionsView"`);
+  return knex.raw(`
+    CREATE OR REPLACE VIEW "SectionsView" AS (
+      SELECT *, ROW_NUMBER () OVER (
+        PARTITION BY "questionnaireId"
+        ORDER BY "order" ASC
+      ) - 1 AS "position"
+      FROM "Sections"
+      WHERE "isDeleted" = false
+    )`);
+};
+
+exports.down = async function() {
+  return Promise.resolve();
+};

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^6.0.0",
-    "eq-author-graphql-schema": "^0.28.0",
+    "eq-author-graphql-schema": "^0.29.0",
     "express": "^4.15.3",
     "express-pino-logger": "^3.0.1",
     "graphql": "^0.13.2",

--- a/repositories/SectionRepository.js
+++ b/repositories/SectionRepository.js
@@ -32,15 +32,16 @@ module.exports.insert = function insert(args) {
       position
     )
       .then(order => Object.assign(args, { order }))
-      .then(pick(["title", "questionnaireId", "order"]))
+      .then(pick(["title", "alias", "questionnaireId", "order"]))
       .then(section => Section.create(section, trx))
       .then(head);
   });
 };
 
-module.exports.update = function update({ id, title, isDeleted }) {
+module.exports.update = function update({ id, title, alias, isDeleted }) {
   return Section.update(id, {
     title,
+    alias,
     isDeleted
   }).then(head);
 };

--- a/repositories/SectionRepository.test.js
+++ b/repositories/SectionRepository.test.js
@@ -17,6 +17,7 @@ const buildQuestionnaire = questionnaire => ({
 
 const buildSection = section => ({
   title: "Test section",
+  alias: "Test alias",
   ...section
 });
 
@@ -56,17 +57,20 @@ describe("SectionRepository", () => {
       questionnaire: { id: questionnaireId }
     } = await setup();
 
-    const result = await SectionRepository.insert(
+    const section = await SectionRepository.insert(
       buildSection({ questionnaireId: questionnaireId })
     );
 
-    await SectionRepository.update({
-      id: result.id,
-      title: "updated title"
-    });
-    const updated = await SectionRepository.getById(result.id);
+    const update = {
+      id: section.id,
+      title: "updated title",
+      alias: "updated alias"
+    };
 
-    expect(updated.title).not.toEqual(result.title);
+    await SectionRepository.update(update);
+    const result = await SectionRepository.getById(section.id);
+
+    expect(result).toMatchObject(update);
   });
 
   it("allow sections to be deleted", async () => {

--- a/tests/schema/mutations/createSection.test.js
+++ b/tests/schema/mutations/createSection.test.js
@@ -5,8 +5,9 @@ describe("createSection", () => {
   const createSection = `
     mutation CreateSection($input: CreateSectionInput!) {
       createSection(input: $input) {
-        id,
+        id
         title
+        alias
       }
     }
   `;
@@ -26,6 +27,7 @@ describe("createSection", () => {
 
   it("should allow creation of Section", async () => {
     const input = {
+      alias: "Section alias",
       title: "Test section",
       description: "Test section description",
       questionnaireId: QUESTIONNAIRE_ID

--- a/tests/schema/mutations/updateSection.test.js
+++ b/tests/schema/mutations/updateSection.test.js
@@ -5,8 +5,9 @@ describe("updateSection", () => {
   const updateSection = `
     mutation UpdateSection($input: UpdateSectionInput!) {
       updateSection(input: $input) {
-        id,
+        id
         title
+        alias
       }
     }
   `;
@@ -23,6 +24,7 @@ describe("updateSection", () => {
     const input = {
       id: "1",
       title: "Updated section title",
+      alias: "Updated section alias",
       description: "This is an updated section description"
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,9 +1297,9 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-eq-author-graphql-schema@^0.28.0:
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.28.0.tgz#7567804deefba6728b70d5707d302eef570f4495"
+eq-author-graphql-schema@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.29.0.tgz#631f9d37d53060e9c7879cc660920ad28c67a473"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
### What is the context of this PR?
- Adds `alias` field to `Sections`
- https://trello.com/c/fvYKd06w/571-aliases-for-sections-9

### How to review 
- Run tests
- Use eQ Author GraphQL API explorer to test mutations and queries eg.

```
mutation CreateSection($input: CreateSectionInput!) {
  createSection(input: $input) {
    alias
  }
}

#Query Variables
{
  "input": {
    "title": "fooBarTitle",
    "alias": "fooBarAlias",
    "questionnaireId": "1"
  }
}
```

```
mutation UpdateSection($input: UpdateSectionInput!) {
  updateSection(input: $input) {
    alias
  }
}

#Query Variables
{
  "input": {
    "id": "1",
    "alias": "fooBarAlias"
  }
}
```

```
query GetSection($id: ID!) {
  section(id: $id) {
    title
    displayName
    alias
  }
}

#Query Variables
{
  "id": "1",
  "alias": "fooBarAlias"
}
```

### Dependencies 

- [x] https://github.com/ONSdigital/eq-author-graphql-schema/pull/65