### PR TITLE
Add displayName for metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^6.0.0",
-    "eq-author-graphql-schema": "^0.30.0",
+    "eq-author-graphql-schema": "^0.32.0",
     "express": "^4.15.3",
     "express-pino-logger": "^4.0.0",
     "graphql": "^0.13.2",

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -457,7 +457,8 @@ const Resolvers = {
         return null;
       }
       return new Date(value);
-    }
+    },
+    displayName: metadata => getName(metadata, "Metadata")
   },
 
   Date: GraphQLDate,

--- a/tests/schema/queries/metadata.test.js
+++ b/tests/schema/queries/metadata.test.js
@@ -13,6 +13,7 @@ describe("Metadata query", () => {
           languageValue
           regionValue
           dateValue
+          displayName
         }
       }
     }
@@ -31,8 +32,14 @@ describe("Metadata query", () => {
       }),
       Metadata: mockRepository({
         findAll: [
-          { id: 1, type: "Text", value: "hello" },
-          { id: 2, type: "Language", value: "en" },
+          {
+            id: 1,
+            type: "Text",
+            value: "hello",
+            alias: "Metadata1",
+            key: "UnusedKey"
+          },
+          { id: 2, type: "Language", value: "en", key: "Metadata2" },
           { id: 3, type: "Region", value: "GB_ENG" },
           { id: 4, type: "Date", value: "2018-01-01" }
         ]
@@ -51,25 +58,20 @@ describe("Metadata query", () => {
       questionnaireId: QUESTIONNAIRE_ID
     });
     expect(result.data.questionnaire.metadata).toHaveLength(4);
-    expect(result.data.questionnaire.metadata[0]).toEqual(
-      expect.objectContaining({
-        textValue: "hello"
-      })
-    );
-    expect(result.data.questionnaire.metadata[1]).toEqual(
-      expect.objectContaining({
-        languageValue: "en"
-      })
-    );
-    expect(result.data.questionnaire.metadata[2]).toEqual(
-      expect.objectContaining({
-        regionValue: "GB_ENG"
-      })
-    );
-    expect(result.data.questionnaire.metadata[3]).toEqual(
-      expect.objectContaining({
-        dateValue: "2018-01-01"
-      })
-    );
+    expect(result.data.questionnaire.metadata[0]).toMatchObject({
+      textValue: "hello",
+      displayName: "Metadata1"
+    });
+    expect(result.data.questionnaire.metadata[1]).toMatchObject({
+      languageValue: "en",
+      displayName: "Metadata2"
+    });
+    expect(result.data.questionnaire.metadata[2]).toMatchObject({
+      regionValue: "GB_ENG",
+      displayName: "Untitled Metadata"
+    });
+    expect(result.data.questionnaire.metadata[3]).toMatchObject({
+      dateValue: "2018-01-01"
+    });
   });
 });

--- a/utils/getName.js
+++ b/utils/getName.js
@@ -7,12 +7,13 @@ const defaultNames = {
   Option: "Untitled Label",
   BasicAnswer: "Untitled Answer",
   MultipleChoiceAnswer: "Untitled Answer",
-  CompositeAnswer: "Untitled Answer"
+  CompositeAnswer: "Untitled Answer",
+  Metadata: "Untitled Metadata"
 };
 
 const getName = (entity, typeName) => {
   const title = find(
-    pick(entity, ["alias", "title", "label"]),
+    pick(entity, ["alias", "title", "label", "key"]),
     value => !isEmpty(stripTags(value))
   );
 

--- a/utils/getName.js
+++ b/utils/getName.js
@@ -14,7 +14,12 @@ const defaultNames = {
 const getName = (entity, typeName) => {
   const title = find(
     pick(entity, ["alias", "title", "label", "key"]),
-    value => !isEmpty(stripTags(value))
+    value => {
+      if (!value) {
+        return false;
+      }
+      return !isEmpty(stripTags(value).trim());
+    }
   );
 
   return title ? stripTags(title) : defaultNames[typeName];

--- a/utils/getName.test.js
+++ b/utils/getName.test.js
@@ -61,4 +61,15 @@ describe("getName", () => {
       expect(getName(entity, typeName)).toEqual(entity.label)
     );
   });
+
+  it("should use key if none of the other fields are avaialable", () => {
+    entity = {
+      foo: "I am a title",
+      key: "I am a key"
+    };
+
+    map(keys(defaultNames), typeName =>
+      expect(getName(entity, typeName)).toEqual(entity.key)
+    );
+  });
 });

--- a/utils/getName.test.js
+++ b/utils/getName.test.js
@@ -18,9 +18,20 @@ describe("getName", () => {
 
   it("should use correct key", () => {
     entity = {
+      alias: "I am an alias",
+      title: "I am a title",
+      label: "I am a label",
+      key: "I am a key"
+    };
+
+    map(keys(defaultNames), typeName =>
+      expect(getName(entity, typeName)).toEqual(entity.alias)
+    );
+    entity = {
       alias: "",
       title: "I am a title",
-      label: "I am a label"
+      label: "I am a label",
+      key: "I am a key"
     };
 
     map(keys(defaultNames), typeName =>
@@ -30,11 +41,23 @@ describe("getName", () => {
     entity = {
       alias: "",
       title: "",
-      label: "I am a label"
+      label: "I am a label",
+      key: "I am a key"
     };
 
     map(keys(defaultNames), typeName =>
       expect(getName(entity, typeName)).toEqual(entity.label)
+    );
+
+    entity = {
+      alias: "",
+      title: "",
+      label: "",
+      key: "I am a key"
+    };
+
+    map(keys(defaultNames), typeName =>
+      expect(getName(entity, typeName)).toEqual(entity.key)
     );
   });
 
@@ -59,17 +82,6 @@ describe("getName", () => {
 
     map(keys(defaultNames), typeName =>
       expect(getName(entity, typeName)).toEqual(entity.label)
-    );
-  });
-
-  it("should use key if none of the other fields are avaialable", () => {
-    entity = {
-      foo: "I am a title",
-      key: "I am a key"
-    };
-
-    map(keys(defaultNames), typeName =>
-      expect(getName(entity, typeName)).toEqual(entity.key)
     );
   });
 });

--- a/utils/getName.test.js
+++ b/utils/getName.test.js
@@ -84,4 +84,22 @@ describe("getName", () => {
       expect(getName(entity, typeName)).toEqual(entity.label)
     );
   });
+
+  it("should ignore whitespace", () => {
+    entity = {
+      alias: "<p> </p><p> </p>",
+      label: "Some label"
+    };
+    map(keys(defaultNames), typeName =>
+      expect(getName(entity, typeName)).toEqual(entity.label)
+    );
+
+    entity = {
+      alias: "  ",
+      label: "Some label"
+    };
+    map(keys(defaultNames), typeName =>
+      expect(getName(entity, typeName)).toEqual(entity.label)
+    );
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1333,9 +1333,9 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-eq-author-graphql-schema@^0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.30.0.tgz#90a9a08d2e07ba7e7c867c8c713a2b60e40c590b"
+eq-author-graphql-schema@^0.32.0:
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.32.0.tgz#0ae898ce1b741c6a4c9a56ff906c7c1d7a6f02f3"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
### What is the context of this PR?
Adds a displayName for metadata so we don't have to do this in the UI.

### How to review 
1. Ensure tests pass.
2. Ensure that metadata can be retrieved with a displayName

### Dependencies
- [x] - https://github.com/ONSdigital/eq-author-graphql-schema/pull/69