### PR TITLE
Fix missing js-yaml dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "jest": "^23.0.0",
     "json-web-key": "^0.3.0",
     "jsrsasign": "^8.0.12",
+    "js-yaml": "^3.12.0",
     "knex": "^0.14.6",
     "lodash": "^4.17.4",
     "node-jose": "^1.0.0",


### PR DESCRIPTION
### What is the context of this PR?
A previous commit introduced a new dependency. This was not included in the package.json and caused a runtime error when trying to deploy to staging environment.

This PR adds the dependency to the package.json and therefore should install the dependency when building the container.