### PR TITLE
Modify docker config to read secrets from S3 bucket

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
 Dockerfile
 docker-compose.yml
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,24 @@
 FROM node:8-alpine
+
+RUN apk add --no-cache python3 && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [ ! -e /usr/bin/python ]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache && \
+    pip install --upgrade awscli==1.16.27
+
 EXPOSE 4000
 ENV PORT=4000
 WORKDIR /app
 
 ARG APPLICATION_VERSION
 ENV EQ_AUTHOR_API_VERSION $APPLICATION_VERSION
+ENV AWS_DEFAULT_REGION eu-west-1
 ENV NODE_ENV production
 
-ENTRYPOINT ["yarn", "start"]
+ENTRYPOINT ["./docker-entrypoint.sh"]
 
 COPY . /app
 RUN yarn install

--- a/README.md
+++ b/README.md
@@ -25,10 +25,14 @@ In most cases sensible defaults have been selected.
 
 | Name | Description | Required |
 | --- | --- | --- |
-| `NODE_ENV` | Sets the environment the code is running in | Yes |
+| `RUNNER_SESSION_URL` | Authentication URL for survey runner | Yes |
+| `PUBLISHER_URL` | URL that produces valid survey runner JSON | Yes |
 | `DB_CONNECTION_URI` | Connection string for database | Yes |
-| `PORT` | The port which express listens on (defaults to `4000`). | No |
+| `SECRETS_S3_BUCKET` | Name of S3 bucket where secrets are stored | No |
+| `KEYS_FILE` | Name of the keys file to use inside the bucket | No |
 | `EQ_AUTHOR_API_VERSION` | The current Author API version. This is what gets reported on the /status endpoint | No |
+| `PORT` | The port which express listens on (defaults to `4000`). | No |
+| `NODE_ENV` | Sets the environment the code is running in | No |
 
 ### Run using Docker
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if [ -n "$SECRETS_S3_BUCKET" ]; then
+    echo "Load Secrets from S3 Bucket [$SECRETS_S3_BUCKET]"
+    aws s3 sync s3://$SECRETS_S3_BUCKET/ /secrets
+fi
+
+yarn start

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "main": "app.js",
   "license": "MIT",
   "scripts": {
-    "prestart": "yarn upgrade eq-author-graphql-schema",
     "start": "yarn knex -- migrate:latest && nodemon",
     "start:dev": "yarn knex -- migrate:latest && nodemon --inspect=0.0.0.0:5858",
     "lint": "eslint .",


### PR DESCRIPTION
### What is the context of this PR?

A change is required to the author API so that it is possible to read in secrets from an S3 bucket at runtime.

This is required because the signing and encryption keys used to create the JWT payload differ between dev, preprod and prod. The new launch mechanism works in staging at the moment due to the use of development keys, but will not currently work in pre-prod because the keys are not the same.

This change allows for overriding of the default behaviour with a new environment variable. This allows secrets to be read in from S3 at runtime.

I've also made a few optimisations to how we build the image to speed things up (e.g. no longer copying the contents of node_modules into the container) and updated the README with a few missing environment variable details.

### How to review 
 - Build the docker image using `docker build -t eq-author-api:8-alpine-with-awscli .`
 - Run the container using `docker run -ti eq-author-api:8-alpine-with-awscli`
   The container will fail to run due to missing database.
 - Kill the container and run again with `docker run -ti -e SECRETS_S3_BUCKET=env-secrets eq-author-api:8-alpine-with-awscli`
 - Observe in the output that an attempt was made to read secrets in from env-secrets.

As a final check it's also worth running `docker-compose up --build` to make sure the developer experience is the same/similar to before.
