### PR TITLE
Add previous answer to max value

### DIFF
--- a/migrations/20181004142958_add_entity_type_to_validation_answer_rules.js
+++ b/migrations/20181004142958_add_entity_type_to_validation_answer_rules.js
@@ -1,0 +1,12 @@
+exports.up = function(knex) {
+  return knex.schema.table("Validation_AnswerRules", table => {
+    table
+      .enum("entityType", ["Custom", "PreviousAnswer"])
+      .defaultsTo("Custom")
+      .notNullable();
+  });
+};
+
+exports.down = function() {
+  return Promise.resolve();
+};

--- a/migrations/20181004143754_add_previous_answer_id_to_validation_answer_rules.js
+++ b/migrations/20181004143754_add_previous_answer_id_to_validation_answer_rules.js
@@ -1,0 +1,15 @@
+exports.up = function(knex) {
+  return knex.schema.table("Validation_AnswerRules", table => {
+    table
+      .integer("previousAnswerId")
+      .unsigned()
+      .index()
+      .references("id")
+      .inTable("Answers")
+      .onDelete("SET NULL");
+  });
+};
+
+exports.down = function() {
+  return Promise.resolve();
+};

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "colors": "^1.1.2",
     "cors": "^2.8.3",
     "dotenv": "^6.0.0",
-    "eq-author-graphql-schema": "^0.32.0",
+    "eq-author-graphql-schema": "^0.33.0",
     "express": "^4.15.3",
     "express-pino-logger": "^4.0.0",
     "graphql": "^14.0.2",

--- a/repositories/ValidationRepository.js
+++ b/repositories/ValidationRepository.js
@@ -16,10 +16,18 @@ const getInputType = flow(
 );
 
 const updateValidationRule = input => {
-  const { custom, ...config } = input[getInputType(input)];
+  const {
+    custom,
+    entityType,
+    previousAnswer: previousAnswerId,
+    ...config
+  } = input[getInputType(input)];
+
   return Validation.update(input.id, {
     custom: JSON.stringify(custom),
-    config: JSON.stringify(config)
+    config: JSON.stringify(config),
+    entityType,
+    previousAnswerId
   }).then(head);
 };
 

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -435,7 +435,12 @@ const Resolvers = {
   MaxValueValidationRule: {
     enabled: ({ enabled }) => enabled,
     inclusive: ({ config }) => config.inclusive,
-    custom: ({ custom }) => custom
+    custom: ({ custom }) => custom,
+    entityType: ({ entityType }) => entityType,
+    previousAnswer: ({ previousAnswerId }, args, ctx) =>
+      isNil(previousAnswerId)
+        ? null
+        : ctx.repositories.Answer.getById(previousAnswerId)
   },
 
   EarliestDateValidationRule: {

--- a/schema/resolversTests/validation.test.js
+++ b/schema/resolversTests/validation.test.js
@@ -154,17 +154,18 @@ describe("resolvers", () => {
           id: maxValueId,
           enabled: false,
           inclusive: false,
-          custom: null
+          custom: null,
+          entityType: "Custom"
         }
       });
 
-      expect(currencyValidation).toMatchObject(
+      expect(currencyValidation).toEqual(
         validationObject(
           currencyValidation.minValue.id,
           currencyValidation.maxValue.id
         )
       );
-      expect(numberValidation).toMatchObject(
+      expect(numberValidation).toEqual(
         validationObject(
           numberValidation.minValue.id,
           numberValidation.maxValue.id
@@ -205,11 +206,62 @@ describe("resolvers", () => {
           inclusive: true
         }
       });
+
       expect(result).toMatchObject({
         id: currencyValidation.maxValue.id,
         custom: 10,
         inclusive: true
       });
+    });
+
+    it("can update inclusive and previous answer max values", async () => {
+      const previousAnswer = await createNewAnswer(firstPage, "Number");
+      const currencyAnswer = await createNewAnswer(firstPage, "Currency");
+      const currencyValidation = await queryAnswerValidations(
+        currencyAnswer.id
+      );
+
+      const result = await mutateValidationParameters({
+        id: currencyValidation.maxValue.id,
+        maxValueInput: {
+          previousAnswer: previousAnswer.id,
+          inclusive: true
+        }
+      });
+
+      expect(result).toMatchObject({
+        id: currencyValidation.maxValue.id,
+        previousAnswer: {
+          id: previousAnswer.id
+        },
+        inclusive: true
+      });
+    });
+
+    it("can update inclusive and entity type", async () => {
+      const currencyAnswer = await createNewAnswer(firstPage, "Currency");
+      const currencyValidation = await queryAnswerValidations(
+        currencyAnswer.id
+      );
+
+      const entityTypes = ["Custom", "PreviousAnswer"];
+
+      const promises = entityTypes.map(async entityType => {
+        const result = await mutateValidationParameters({
+          id: currencyValidation.maxValue.id,
+          maxValueInput: {
+            entityType: entityType,
+            inclusive: true
+          }
+        });
+
+        expect(result).toMatchObject({
+          id: currencyValidation.maxValue.id,
+          entityType: entityType
+        });
+      });
+
+      await Promise.all(promises);
     });
   });
 

--- a/tests/utils/graphql.js
+++ b/tests/utils/graphql.js
@@ -565,6 +565,7 @@ const getAnswerValidations = `
             enabled
             inclusive
             custom
+            entityType
           }
          }
          ...on DateValidation {
@@ -615,6 +616,10 @@ mutation updateValidation($input: UpdateValidationRuleInput!){
     ...on MaxValueValidationRule {
       custom
       inclusive
+      entityType
+      previousAnswer {
+        id
+      }
     }
     ...on EarliestDateValidationRule {
       customDate: custom

--- a/yarn.lock
+++ b/yarn.lock
@@ -1591,10 +1591,10 @@ entities@^1.1.1, entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
   integrity sha1-blwtClYhtdra7O+AuQ7ftc13cvA=
 
-eq-author-graphql-schema@^0.32.0:
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.32.0.tgz#0ae898ce1b741c6a4c9a56ff906c7c1d7a6f02f3"
-  integrity sha512-ItYQOVzJ8mIe3Mw5Q3OmNqtPr+dlZnVXucmWjO77jBOhCEZdcA2OHsCOa3IRMo3R+TehhpXLYDYHCdk47DXIMQ==
+eq-author-graphql-schema@^0.33.0:
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.33.0.tgz#0ecd7ccfca99e606aa74de1c4678492055a89390"
+  integrity sha512-kv5gf3xcnA5lYdU+FER2KuIABKoNdwJO6RQKecb95F+lseAxOm00uqbgm+o3JYrdDHhxGExGbrKw4QO+vog+Nw==
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
### What is the context of this PR?
- Adds validation against a previous answer for max value 

### How to review 
- Run tests
- Use eQ Author GraphQL API explorer to test mutations and queries eg.

```
mutation updateValidationRule($input: UpdateValidationRuleInput!) {
  updateValidationRule(input: $input) {
    ...MaxValueValidationRule
    __typename
  }
}

fragment MaxValueValidationRule on MaxValueValidationRule {
  id
  enabled
  custom
  inclusive
  entityType
  previousAnswer {
    id
    displayName
    __typename
  }
  __typename
}


#Query Variables
{
  "input": {
    "id": "2", 
    "maxValueInput": {
      "inclusive": false, 
      "previousAnswer": "1"
    }
  }
}

```

```
query answerWithValidation($id: ID!) {
  answer(id: $id) {
  	... on BasicAnswer {
      validation {
        ... on NumberValidation {
         	maxValue {
            id
            previousAnswer {
              id
              displayName
            }
          } 
        }
      }
    }
  }
}

#Query Variables
{
  "id": "2"
}
```

### Dependencies 

- [x] https://github.com/ONSdigital/eq-author-graphql-schema/pull/77