### PR TITLE
551 duplicate questionnaire

### DIFF
--- a/repositories/QuestionnaireRepository.test.js
+++ b/repositories/QuestionnaireRepository.test.js
@@ -1,3 +1,5 @@
+const fp = require("lodash/fp");
+
 const knex = require("../db");
 const QuestionnaireRepository = require("../repositories/QuestionnaireRepository");
 
@@ -73,5 +75,19 @@ describe("QuestionnaireRepository", () => {
     });
 
     expect(result).toMatchObject({ surveyId: "456" });
+  });
+
+  it("should duplicate a questionnaire", async () => {
+    const { id, ...questionnaire } = await QuestionnaireRepository.insert(
+      buildQuestionnaire()
+    );
+    const duplicatedQuestionnaire = await QuestionnaireRepository.duplicate(id);
+
+    const filterUnwanted = fp.omit(["id", "createdAt", "updatedAt"]);
+
+    expect(filterUnwanted(duplicatedQuestionnaire)).toMatchObject({
+      ...filterUnwanted(questionnaire),
+      title: `Copy of ${questionnaire.title}`
+    });
   });
 });

--- a/repositories/strategies/duplicateStrategy.js
+++ b/repositories/strategies/duplicateStrategy.js
@@ -240,6 +240,35 @@ const duplicateSectionStrategy = async (
   return duplicateSection;
 };
 
+const duplicateQuestionnaireStrategy = async (
+  trx,
+  questionnaire,
+  overrides = {}
+) => {
+  const duplicateQuestionnaire = await duplicateRecord(
+    trx,
+    "Questionnaires",
+    questionnaire,
+    overrides
+  );
+  const sectionsToDuplicate = await selectData(trx, "SectionsView", "*", {
+    questionnaireId: questionnaire.id
+  });
+
+  await Promise.all(
+    sectionsToDuplicate.map(({ position, ...section }) =>
+      duplicateSectionStrategy(trx, section, position, {
+        parentRelation: {
+          id: duplicateQuestionnaire.id,
+          columnName: "questionnaireId"
+        }
+      })
+    )
+  );
+
+  return duplicateQuestionnaire;
+};
+
 Object.assign(module.exports, {
   insertData,
   selectData,
@@ -247,5 +276,6 @@ Object.assign(module.exports, {
   duplicateOptionStrategy,
   duplicateAnswerStrategy,
   duplicatePageStrategy,
-  duplicateSectionStrategy
+  duplicateSectionStrategy,
+  duplicateQuestionnaireStrategy
 });

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -50,9 +50,8 @@ const Resolvers = {
       ctx.repositories.Questionnaire.remove(args.input.id),
     undeleteQuestionnaire: (_, args, ctx) =>
       ctx.repositories.Questionnaire.undelete(args.input.id),
-    duplicateQuestionnaire: () => {
-      throw new Error("Not implemented");
-    },
+    duplicateQuestionnaire: (_, args, ctx) =>
+      ctx.repositories.Questionnaire.duplicate(args.input.id),
 
     createSection: async (root, args, ctx) => {
       const section = await ctx.repositories.Section.insert(args.input);

--- a/schema/resolversTests/duplication.test.js
+++ b/schema/resolversTests/duplication.test.js
@@ -66,4 +66,31 @@ describe("Duplication", () => {
       duplicateSection: { id: "2" }
     });
   });
+
+  it("should be able to duplicate a questionnaire", async () => {
+    const ctx = {
+      repositories: {
+        Questionnaire: {
+          duplicate: jest.fn(() => ({
+            id: 2,
+            title: "Duplicate Questionnaire"
+          }))
+        }
+      }
+    };
+    const query = `
+    mutation duplicateQuestionnaire($input: DuplicateQuestionnaireInput!) {
+      duplicateQuestionnaire(input: $input) {
+        id
+      }
+    }
+    `;
+
+    const result = await executeQuery(query, { input: { id: "1" } }, ctx);
+    expect(result.errors).toBeUndefined();
+    expect(ctx.repositories.Questionnaire.duplicate).toHaveBeenCalledWith("1");
+    expect(result.data).toMatchObject({
+      duplicateQuestionnaire: { id: "2" }
+    });
+  });
 });


### PR DESCRIPTION
### What is the context of this PR?
Builds on #156 

This adds basic duplication of questionnaire which includes all sections, pages, answers etc.

Metadata, piping, routing, previous answer validations etc will be dealt with in separate PRs.

### How to review 
1. Checkout author branch `551-duplicate-questionnaire`
1. Ensure you can duplicate the questionnaire with all pages, sections, answers and validations (apart from max value against previous answers).
