### PR TITLE
Fix issue piping Date metadata.

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ const pinoMiddleware = require("express-pino-logger");
 const { PORT } = require("./config/settings");
 const createLogger = require("./utils/createLogger");
 const status = require("./middleware/status");
-const getLaunchUrl = require("./middleware/launch");
+const { getLaunchUrl } = require("./middleware/launch");
 
 const app = express();
 const pino = pinoMiddleware();

--- a/middleware/launch.test.js
+++ b/middleware/launch.test.js
@@ -1,4 +1,4 @@
-const getLaunchUrl = require("./launch");
+const { buildClaims, getLaunchUrl } = require("./launch");
 const mockRepository = require("../tests/utils/mockRepository");
 
 let repositories;
@@ -84,5 +84,32 @@ describe("launcher middleware", () => {
     await getLaunchUrl(ctx)(req, res, next);
 
     expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("should convert date values to ISO string dates when building claims", () => {
+    expect(
+      buildClaims([{ id: 1, key: "hello", type: "Date", value: "01/01/2018" }])
+    ).toMatchObject({
+      claims: {
+        hello: "2018-01-01"
+      }
+    });
+  });
+
+  it("should convert date values to ISO string even if ISO format already", () => {
+    expect(
+      buildClaims([
+        {
+          id: 1,
+          key: "hello",
+          type: "Date",
+          value: "2018-01-01T00:00:00+00:00"
+        }
+      ])
+    ).toMatchObject({
+      claims: {
+        hello: "2018-01-01"
+      }
+    });
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
It is not currently possible to pipe Date metadata into a questionnaire. Survey runner expects date values to be passed through in ISO format (yyyy-mm-dd) and author currently passes them in dd/mm/yyyy format.

The result is that the survey will launch but runner will throw a 403 authentication error (since the JWT token is considered invalid).

This fix formats Date values according to ISO format before they are passed into the claims of the JWT token. After applying this change, it should be possible to launch a questionnaire that pipes in a Date metadata value and have it show up within runner.

### How to review 
- Run the application using eq-compose
- Confirm that you cannot launch a questionnaire that pipes a Date metadata value
- Change the config of eq-compose so that it pulls down this branch's image for the Author API.
- Run the application again and confirm you can pipe Date metadata values successfully and launch into runner showing the value.
- All existing checks and tests should pass.
