### PR TITLE
Fixed bug with changing comparator creating new conVal

### DIFF
--- a/repositories/strategies/routingStrategy.js
+++ b/repositories/strategies/routingStrategy.js
@@ -173,14 +173,14 @@ const updateRoutingConditionStrategy = async (
       conditionId: routingConditionId
     });
     comparator = "Equal";
+    if (
+      !isNil(routingConditionAnswer) &&
+      includes(["Currency", "Number"], routingConditionAnswer.type)
+    ) {
+      await createSpecificConditionValue(trx, routingConditionId);
+    }
   }
 
-  if (
-    !isNil(routingConditionAnswer) &&
-    includes(["Currency", "Number"], routingConditionAnswer.type)
-  ) {
-    await createSpecificConditionValue(trx, routingConditionId);
-  }
   return updateRoutingCondition(
     trx,
     routingConditionId,


### PR DESCRIPTION
### What is the context of this PR?
In the last PR I missed a bug where changing the comparator on the front end would create a new condition value for every change. This pr fixes that instance and adds a test to prevent it from recurring.

### How to review 
New test passes, and change makes sense.
