### PR TITLE
Fixed flaky resolver tests

### DIFF
--- a/schema/resolvers.test.js
+++ b/schema/resolvers.test.js
@@ -492,7 +492,7 @@ describe("resolvers", () => {
     const parentAnswer = await createNewAnswer(firstPage, "Checkbox");
     const other = await createOther(parentAnswer);
 
-    expect(createOther(parentAnswer)).resolves.toBeNull();
+    await expect(createOther(parentAnswer)).resolves.toBeNull();
 
     const updatedParent = await refreshAnswerDetails(parentAnswer);
     expect(updatedParent.other).toMatchObject(other);
@@ -588,7 +588,7 @@ describe("resolvers", () => {
       }
     });
 
-    expect(
+    return expect(
       executeQuery(getBasicRoutingQuery, { id: firstPage.id }, ctx)
     ).resolves.toMatchObject({
       data: {


### PR DESCRIPTION
### What is the context of this PR?
Fixes a bug where if the docker image ran slowly a promise in one of the tests would not resolve correctly and would somehow overflow?!? into the next test.

### How to review 
Tests pass even when you only give the docker engine 1 core and 1gb of memory to play with.
