### PR TITLE
729 Section intro bug fix

### DIFF
--- a/migrations/20181114153441_ammended_section_intro_column_types.js
+++ b/migrations/20181114153441_ammended_section_intro_column_types.js
@@ -1,0 +1,20 @@
+const { noop } = require("lodash");
+
+exports.up = async function(knex) {
+  await knex.raw(`DROP VIEW "SectionsView"`);
+  await knex.schema.table("Sections", table => {
+    table.text("introductionTitle").alter();
+    table.text("introductionContent").alter();
+  });
+  return knex.raw(`
+    CREATE OR REPLACE VIEW "SectionsView" AS (
+      SELECT *, ROW_NUMBER () OVER (
+        PARTITION BY "questionnaireId"
+        ORDER BY "order" ASC
+      ) - 1 AS "position"
+      FROM "Sections"
+      WHERE "isDeleted" = false
+    )`);
+};
+
+exports.down = noop;


### PR DESCRIPTION
### What is the context of this PR?
There is a bug with section introductions where you can enter more than 255 characters and wipe the all the text boxes on the page. This is because the columns in the postgress table were of type string and needed to be type text. I have created a new migration to fix this and alter the columns to be of type text

### How to review 
Run tests
Compare with master and make sure bug is now fixed
