### PR TITLE
Tech Debt - Remove legacy watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "start": "yarn knex -- migrate:latest && nodemon",
-    "start:dev": "yarn knex -- migrate:latest && nodemon -L --inspect=0.0.0.0:5858",
+    "start:dev": "yarn knex -- migrate:latest && nodemon --inspect=0.0.0.0:5858",
     "lint": "eslint .",
     "test": "NODE_ENV=test ./scripts/test.sh",
     "knex": "knex --knexfile config/knexfile.js --cwd .",


### PR DESCRIPTION
### What is the context of this PR?
Remove legacy watch. It seems to be resolved by docker-compose build.

This was killing the CPU on my Mac.

### How to review 
1. Checkout this branch
1. Ensure you can change files and the server in docker restarts.

If not.
1. Run `docker-compose build` then `docker-compose up`
1. Then see if it works.
